### PR TITLE
Add GitHub Actions for PR builds and production deploys

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Build production
+    name: Build production (test build)
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -1,0 +1,18 @@
+name: Build Community Catalog PR branch
+
+on:
+  # Run this workflow on changes to any PR.
+  pull_request:
+
+  # Allow running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build production
+    uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
+    with:
+      commit_id: ${{ github.sha }}
+      node_version: '16.x'
+      output: 'dist'
+      script: 'build'

--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -1,4 +1,4 @@
-name: Build Community Catalog PR branch
+name: Build Community Catalog PR branch (test build)
 
 on:
   # Run this workflow on changes to any PR.

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,4 +1,4 @@
-name: Deploy Community Catalog Production
+name: Deploy Community Catalog production
 
 on:
     # Run this workflow on push to production-release tag (via chatops)

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,0 +1,44 @@
+name: Deploy Community Catalog Production
+
+on:
+    # Run this workflow on push to production-release tag (via chatops)
+    push:
+        tags:
+          - production-release
+
+    # Allow running this workflow manually from the Actions tab
+    workflow_dispatch:
+
+jobs:
+  build:
+    name: Build production
+    uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
+    with:
+      commit_id: ${{ github.sha }}
+      node_version: '16.x'
+      output: 'dist'
+      script: 'build'
+
+  deploy:
+    name: Deploy production
+    uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main
+    needs: build
+    with:
+      source: 'dist'
+      target: 'community-catalog.zooniverse.org'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}
+
+  slack_notification:
+    name: Send Slack notification
+    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
+    needs: deploy
+    if: always()
+    with:
+      commit_id: ${{ github.sha }}
+      job_name: Build production / build
+      status: ${{ needs.deploy.result }}
+      title: 'Community Catalog Production deploy complete'
+      title_link: 'https://community-catalog.zooniverse.org'
+    secrets:
+      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   run_tests:
+    name: Run tests
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,23 @@
+name: Run Community Catalog tests
+
+on:
+  # Run this workflow on creation (or sync to source branch) of a new pull request
+  pull_request:
+
+  # Allow running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Use Node.js 16
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+
+    - run: npm ci
+    - run: npm test

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ How to run the website on your computer:
 - Open `https://local.zooniverse.org:8080` in your browser to view the website.
 
 How to deploy the website to community-catalog.zooniverse.org:
-- TODO
+- Deploys are performed via GitHub actions.
+  - Option 1: Check the `#deploys` channel on our Zooniverse Slack for the necessary chat commands.
+  - Option 2: manually update the `production-release` tag to the latest commit in this repo (or the commit you wish to deploy).
+- Monitor progress on the [GitHub Actions tab](https://github.com/zooniverse/community-catalog/actions) of this repo.  
 
 ### Developer Notes
 

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,4 +1,7 @@
 {
+  "moduleNameMapper": {
+    "^@src/(.*)$": "<rootDir>/src/$1"
+  },
   "roots": [
     "<rootDir>/src"
   ],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -20,7 +20,7 @@ module.exports = {
   entry: './src/main.js',
   output: {
     filename: '[name].js',
-    path: path.resolve(__dirname, 'build'),
+    path: path.resolve(__dirname, 'dist'),
   },
   mode: 'development',
   module: {


### PR DESCRIPTION
## PR Overview

This PR adds GitHub Actions to the repo.

- New: the project can be deployed via Slack's bot commands, to `https://community-catalog.zooniverse.org/`
  - Note: requires https://github.com/zooniverse/static/pull/318
- New: when a PR branch is created, a build automatically runs.
  - [x] TODO: this repo should be configured so that a successful build is necessary to merge the PR
  - [x] TODO: figure out how tests (`npm test`) are run via GitHub Actions, again to make sure the PR can't be merged otherwise.

Dev notes: templates used were [Classrooms's actions](https://github.com/zooniverse/classroom/tree/master/.github/workflows). Initially I used [Zoo Notes](https://github.com/zooniverse/zoo-notes/tree/master/.github/workflows) since that had a more recent update, but that repo's using `yarn` and React Create App.

### Status

I still need to figure out those TODOs, but this PR is pretty safe to review on its own. I might merge this "deploy actions" first then solve the "run tests action" separately (because I need to debug some Jest setup as well)