### PR TITLE
Fix Jest: sync with Webpack aliases

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,4 +1,7 @@
 {
+  "moduleNameMapper": {
+    "^@src/(.*)$": "<rootDir>/src/$1"
+  },
   "roots": [
     "<rootDir>/src"
   ],


### PR DESCRIPTION
## PR Overview

Merge target: PR #4

This PR fixes Jest tests. Prior to this PR, the tests were breaking because they didn't recognise the Webpack alises, e.g. `@src/App/Tester` is supposed to map to `(root)/src/App/Tester`

- Solution was to use Jest's `ModuleNameMapper` [config option](https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring).
- See [Jest documentation on working with webpack.](https://jestjs.io/docs/webpack)