### PR TITLE
Build with Node 18 LTS

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -13,6 +13,6 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: 'lts/hydrogen'
       output: 'dist'
       script: 'build'

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -15,7 +15,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: 'lts/hydrogen'
       output: 'dist'
       script: 'build'
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
 
-    - name: Use Node.js 16
+    - name: Use Node.js 18
       uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 'lts/hydrogen'
 
     - run: npm ci
     - run: npm test


### PR DESCRIPTION
- Build and deploy with Node 18 LTS (`lts/hydrogen`.)
- Run the tests, and a test Webpack build, on Node 18.