### PR TITLE
Fix localhost for dev server & specify Node ver

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
   },
   "overrides": {
     "trim": "^1.0.1"
+  },
+  "engines": {
+    "node": ">= 18",
+    "npm": ">= 9"
   }
 }

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,7 +14,6 @@ module.exports = {
       'localhost',
       '.zooniverse.org'
     ],
-    host: process.env.HOST || 'localhost',
     server: 'https'
   },
   entry: './src/main.js',


### PR DESCRIPTION
## PR Overview

This is a small miscellaneous fix.

- After the introduction of Node 18 in recent updates, the Webpack dev server for local development no longer allows us to view the website via `local.zooniverse.org:8080`, insisting that this has to be `localhost:8080`
  - Solution to this was to remove the specific `host` from webpack config
- Additionally, package.json now specifies the required Node and npm versions, for local development.