### PR TITLE
Production Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Zooniverse-powered website for exploring community-tagged images",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --config webpack.dev.js",
+    "build": "webpack --config webpack.prod.js",
     "start": "webpack serve --config webpack.dev.js",
     "test": "jest"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,50 @@
+const path = require('path')
+const webpack = require('webpack')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+
+const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
+  template: './src/index.html',
+  filename: 'index.html',
+  inject: 'body'
+})
+
+module.exports = {
+  entry: './src/main.js',
+  output: {
+    filename: '[name].js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/',
+  },
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: 'babel-loader'
+      },
+      {
+        test: /\.ico$/i,
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]',
+        },
+      },
+    ]
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      favicon: 'src/favicon.ico',
+      process: 'process/browser',
+    }),
+    HtmlWebpackPluginConfig
+  ],
+  resolve: {
+    alias: {
+      '@src': path.resolve(__dirname, 'src'),
+    },
+    fallback: {
+      'url': require.resolve('url/'),  // Required by panoptes-client
+    },
+  },
+}


### PR DESCRIPTION
## PR Overview

This PR fixes the production build.

- Previously, the production build would be linking users to _staging_ data. This has been fixed.
  - This PR adds a proper `webpack.prod.js` config, which is the same as .dev.js, except it loses devServer and switches mode to production.
  - Derp, apparently I forgot to put in `<!DOCTYPE html>` in the index.html 