### PR TITLE
Fix Multiple Projects

### DIFF
--- a/src/components/KeywordsList/KeywordsList.js
+++ b/src/components/KeywordsList/KeywordsList.js
@@ -17,10 +17,10 @@ function KeywordsList () {
   const [ keywordsData, setKeywordsData ] = useState([])
 
   useEffect(function () {
-    fetchKeywords({ 
-      setData: setKeywordsData,
-      projectId: projectId
-    })
+    fetchKeywords(
+      projectId,
+      setKeywordsData
+    )
 
   }, [ projectId ])
 

--- a/src/components/KeywordsList/KeywordsList.js
+++ b/src/components/KeywordsList/KeywordsList.js
@@ -12,15 +12,17 @@ const KeywordLink = styled(Link)`
 `
 function KeywordsList () {
   const store = useStores()
+  const projectId = store.project?.id
+  const projectSlug = store.project?.slug
   const [ keywordsData, setKeywordsData ] = useState([])
 
   useEffect(function () {
     fetchKeywords({ 
       setData: setKeywordsData,
-      projectId: store.project?.id
+      projectId: projectId
     })
 
-  }, [])
+  }, [ projectId ])
 
   return (
     <Box elevation='medium'>
@@ -38,7 +40,7 @@ function KeywordsList () {
         wrap={true}
       >
         {keywordsData.map((keyword, i) => (
-          <KeywordLink to={`/search?query=${encodeURIComponent(keyword.name)}`} key={`keyword-${i}`}>
+          <KeywordLink to={`/projects/${projectSlug}/search?query=${encodeURIComponent(keyword.name)}`} key={`keyword-${i}`}>
             <Box
               background='white'
               elevation='xsmall'

--- a/src/components/KeywordsList/KeywordsList.js
+++ b/src/components/KeywordsList/KeywordsList.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Box, Text } from 'grommet'
 import styled from 'styled-components'
+import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
 import fetchKeywords from '@src/helpers/fetchKeywords.js'
@@ -9,8 +10,7 @@ import fetchKeywords from '@src/helpers/fetchKeywords.js'
 const KeywordLink = styled(Link)`
   text-decoration: none;
 `
-
-export default function KeywordsList () {
+function KeywordsList () {
   const store = useStores()
   const [ keywordsData, setKeywordsData ] = useState([])
 
@@ -62,3 +62,5 @@ export default function KeywordsList () {
     </Box>
   )
 }
+
+export default observer(KeywordsList)

--- a/src/components/SearchResultsList/SearchResult.js
+++ b/src/components/SearchResultsList/SearchResult.js
@@ -2,17 +2,16 @@ import { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
 import { Link } from 'react-router-dom'
 
-import { useStores } from '@src/store'
 import SubjectImage from '@src/components/SubjectImage'
 import fetchSubject from '@src/helpers/fetchSubject.js'
 
 export default function SearchResult ({
   subjectId = '',
+  projectSlug = '',
+  titleField = '',
 }) {
-  const store = useStores()
-  const projectSlug = store.project?.slug || ''
-
   const [ subjectData, setSubjectData ] = useState(null)
+  const title = subjectData?.metadata?.[titleField] || ''
 
   useEffect(function () {
     if (subjectId) fetchSubject(subjectId, setSubjectData)
@@ -34,9 +33,11 @@ export default function SearchResult ({
           width={200}
           height={200}
         />
-        <Box pad='small'>
-          <Text color='drawing-pink'>Lorem Ipsum, I don't know what should be here</Text>
-        </Box>
+        {title && (
+          <Box pad='small'>
+            <Text>{title}</Text>
+          </Box>
+        )}
       </Box>
     </Link>
   )

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -11,11 +11,12 @@ function SearchResultsList ({
   query = 'tables',
 }) {
   const store = useStores()
+  const projectId = store.project?.id
   const [ searchResults, setSearchResults ] = useState([])
 
   useEffect(function () {
-    fetchTagSearchResults(store.project?.id, query, setSearchResults)
-  }, [ query ])
+    fetchTagSearchResults(projectId, query, setSearchResults)
+  }, [ projectId, query ])
 
   return (
     <Box

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -12,6 +12,8 @@ function SearchResultsList ({
 }) {
   const store = useStores()
   const projectId = store.project?.id
+  const projectSlug = store.project?.slug || ''
+  const titleField = store.project?.titleField || ''
   const [ searchResults, setSearchResults ] = useState([])
 
   useEffect(function () {
@@ -35,6 +37,8 @@ function SearchResultsList ({
         {searchResults.map(sr => (
           <SearchResult
             subjectId={sr.taggable_id.toString()}
+            projectSlug={projectSlug}
+            titleField={titleField}
             key={sr.taggable_id}
           />
         ))}

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -8,7 +8,7 @@ import fetchTagSearchResults from '@src/helpers/fetchTagSearchResults.js'
 import SearchResult from './SearchResult.js'
 
 function SearchResultsList ({
-  query = 'tables',
+  query = '',
 }) {
   const store = useStores()
   const projectId = store.project?.id

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -1,12 +1,13 @@
 import { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
+import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
 import fetchTagSearchResults from '@src/helpers/fetchTagSearchResults.js'
 
 import SearchResult from './SearchResult.js'
 
-export default function SearchResultsList ({
+function SearchResultsList ({
   query = 'tables',
 }) {
   const store = useStores()
@@ -41,3 +42,5 @@ export default function SearchResultsList ({
     </Box>
   )
 }
+
+export default observer(SearchResultsList)

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
+import { observer } from 'mobx-react'
 
+import { useStores } from '@src/store'
 import fetchKeywords from '@src/helpers/fetchKeywords'
 
 const KeywordLink = styled(Link)`
@@ -12,17 +14,20 @@ const KeywordLink = styled(Link)`
 export default function SubjectKeywords ({
   subject = undefined,
 }) {
+  const store = useStores()
+  const projectId = store.project?.id
 
   const [ keywordsData, setKeywordsData ] = useState([])
 
   useEffect(function () {
     if (subject) {
-      fetchKeywords({
-        setData: setKeywordsData,
+      fetchKeywords(
+        projectId,
+        setKeywordsData,
         subject
-      })
+      )
     }
-  }, [ subject ])
+  }, [ projectId, subject ])
 
   return (
     <Box

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -41,7 +41,10 @@ function SubjectKeywords ({
         wrap={true}
       >
         {keywordsData.map((keyword, i) => (
-          <KeywordLink to={`/search?query=${encodeURIComponent(keyword.name)}`}>
+          <KeywordLink
+            key={`subject-keyword-${i}`}
+            to={`/search?query=${encodeURIComponent(keyword.name)}`}
+          >
             <Box
               background='light-2'
               elevation='xsmall'

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -10,8 +10,7 @@ import fetchKeywords from '@src/helpers/fetchKeywords'
 const KeywordLink = styled(Link)`
   text-decoration: none;
 `
-
-export default function SubjectKeywords ({
+function SubjectKeywords ({
   subject = undefined,
 }) {
   const store = useStores()
@@ -58,3 +57,5 @@ export default function SubjectKeywords ({
     </Box>
   )
 }
+
+export default observer(SubjectKeywords)

--- a/src/components/SubjectMetadata/SubjectMetadata.js
+++ b/src/components/SubjectMetadata/SubjectMetadata.js
@@ -1,4 +1,4 @@
-import { Box, Table, TableCell, TableRow, Text } from 'grommet'
+import { Box, Table, TableBody, TableCell, TableRow, Text } from 'grommet'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
@@ -25,16 +25,18 @@ export default function SubjectMetadata ({
         INSTITUTIONAL METADATA:
       </Text>
       <Table>
-        {metadata.map(m => (
-          <TableRow>
-            <TableCell>
-              <strong>{m.key}</strong>
-            </TableCell>
-            <TableCell>
-              {m.value}
-            </TableCell>
-          </TableRow>
-        ))}
+        <TableBody>
+          {metadata.map((m, i) => (
+            <TableRow key={`subject-metadata-${i}`}>
+              <TableCell>
+                <strong>{m.key}</strong>
+              </TableCell>
+              <TableCell>
+                {m.value}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
       </Table>
       <Text color='drawing-pink'>(Should this be pulled from Panoptes or aux database?)</Text>
     </Box>

--- a/src/helpers/fetchKeywords.js
+++ b/src/helpers/fetchKeywords.js
@@ -1,10 +1,10 @@
 import { talkAPI } from '@zooniverse/panoptes-js'
 
-export default async function fetchKeywords ({
+export default async function fetchKeywords (
   projectId,
   setData = (data) => { console.log('fetchKeywords: ', data) },
   subject = undefined,
-}) {
+) {
   if (!projectId) return
 
   // Examples:

--- a/src/helpers/fetchKeywords.js
+++ b/src/helpers/fetchKeywords.js
@@ -1,10 +1,12 @@
 import { talkAPI } from '@zooniverse/panoptes-js'
 
 export default async function fetchKeywords ({
-  projectId = '',
+  projectId,
   setData = (data) => { console.log('fetchKeywords: ', data) },
   subject = undefined,
 }) {
+  if (!projectId) return
+
   // Examples:
   // - Fetch all popular keywords for a project: https://talk.zooniverse.org/tags/popular?http_cache=true&section=project-12268&limit=20&page_size=20
   // - Fetch all keywords for a specific subject: https://talk.zooniverse.org/tags/popular?http_cache=true&section=project-12268&limit=20&page_size=20&taggable_type=Subject&taggable_id=69734873

--- a/src/helpers/fetchSubject.js
+++ b/src/helpers/fetchSubject.js
@@ -1,9 +1,11 @@
 import { subjects } from '@zooniverse/panoptes-js'
 
 export default async function fetchSubject (
-  subjectId = '',
+  subjectId,
   setData = (data) => { console.log('fetchSubject: ', data) },
 ) {
+  if (!subjectId) return
+
   try {
     const { body } = await subjects.get({ id: subjectId })
     const [ data ] = body.subjects

--- a/src/helpers/fetchTagSearchResults.js
+++ b/src/helpers/fetchTagSearchResults.js
@@ -1,10 +1,12 @@
 import { talkAPI } from '@zooniverse/panoptes-js'
 
 export default async function fetchTagSearchResults (
-  projectId = '',
+  projectId,
   query = '',
   setData = (data) => { console.log('fetchTagSearchResults: ', data) }
 ) {
+  if (!projectId) return
+
   // Example: https://talk.zooniverse.org/tags/popular?http_cache=true&page=1&taggable_type=Subject&section=project-7929&name=flares
   try {
     const response = await talkAPI.get('/tags/popular', {

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -12,13 +12,13 @@ import getQuery from '@src/helpers/getQuery'
 function HomePage () {
   const store = useStores()
   const projectSlug = store.project?.slug || ''
+  const exampleSubjects = store.project?.exampleSubjects || []
   const exampleQuery = store.project?.exampleQuery || ''
 
   const imgWidth = 600
   const imgHeight = 300
 
-  const query = getQuery() || 'tables'
-  const subjects = [ '69734802', '69734801', '69734803' ]
+  const query = getQuery() || exampleQuery
 
   return (
     <>
@@ -35,7 +35,7 @@ function HomePage () {
           <Carousel
             wrap={true}
           >
-            {subjects.map(sbjId => (
+            {exampleSubjects.map(sbjId => (
               <Link to={`/projects/${projectSlug}/subject/${sbjId}`} key={`home-subject-${sbjId}`}>
                 <SubjectImage
                   subjectId={sbjId}
@@ -54,7 +54,7 @@ function HomePage () {
         </Box>
       </Box>
       <KeywordsList />
-      <SearchResultsList query={exampleQuery} />
+      <SearchResultsList query={query} />
     </>
   )
 }

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -12,6 +12,7 @@ import getQuery from '@src/helpers/getQuery'
 function HomePage () {
   const store = useStores()
   const projectSlug = store.project?.slug || ''
+  const exampleQuery = store.project?.exampleQuery || ''
 
   const imgWidth = 600
   const imgHeight = 300
@@ -53,7 +54,7 @@ function HomePage () {
         </Box>
       </Box>
       <KeywordsList />
-      <SearchResultsList query={query} />
+      <SearchResultsList query={exampleQuery} />
     </>
   )
 }

--- a/src/projects.json
+++ b/src/projects.json
@@ -7,7 +7,8 @@
       "metadata_fields": [
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
       ],
-      "exampleQuery": "barbados"
+      "exampleQuery": "barbados",
+      "titleField": "folder"
     }, {
       "name": "Scarlets & Blues (Performance Test Only)",
       "slug": "bogden/scarlets-and-blues",
@@ -15,7 +16,8 @@
       "metadata_fields": [
         "Date", "Page", "image", "Catalogue"
       ],
-      "exampleQuery": "tables"
+      "exampleQuery": "tables",
+      "titleField": "Catalogue"
     }
   ]
 }

--- a/src/projects.json
+++ b/src/projects.json
@@ -6,14 +6,16 @@
       "id": 21084,
       "metadata_fields": [
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
-      ]
+      ],
+      "exampleQuery": "barbados"
     }, {
       "name": "Scarlets & Blues (Performance Test Only)",
       "slug": "bogden/scarlets-and-blues",
       "id": 12268,
       "metadata_fields": [
         "Date", "Page", "image", "Catalogue"
-      ]
+      ],
+      "exampleQuery": "tables"
     }
   ]
 }

--- a/src/projects.json
+++ b/src/projects.json
@@ -7,7 +7,8 @@
       "metadata_fields": [
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
       ],
-      "exampleQuery": "barbados",
+      "exampleQuery": "devtest",
+      "exampleSubjects": [ "87892458", "87892456", "87892462" ],
       "titleField": "folder"
     }, {
       "name": "Scarlets & Blues (Performance Test Only)",
@@ -17,6 +18,7 @@
         "Date", "Page", "image", "Catalogue"
       ],
       "exampleQuery": "tables",
+      "exampleSubjects": [ "69734802", "69734801", "69734803" ],
       "titleField": "Catalogue"
     }
   ]


### PR DESCRIPTION
## PR Overview

Follows #77

Followup PR! Seems like a missed a few bugs in the previous update that added multi-project support, and while I was at it, I threw in some additional improvements.

- Project Improvements (Project Config):
  - Each project can now have its own "example subjects" that are shown on its home page.
  - Each project can now have its own "example query" that populates the search results on its home page. (This replaces the hardcoded query of "tables", which only made sense for Scarlets & Blues)
  - Each project can now designate one of its metadata fields as its "title field". (This replaces the "Lorem Ipsum" text on each Subject Item in the search results list)
- Other Improvements: fetch functions now stop executing if no Project ID is given
- Fixes:
  - KeywordsList, SearchResultsList, SubjectKeywords weren't rendering properly on production, due to missing observers.

### Status

Ready to go!