### PR TITLE
Add Database search results

### DIFF
--- a/src/components/ProjectContainer/ProjectContainer.js
+++ b/src/components/ProjectContainer/ProjectContainer.js
@@ -19,7 +19,7 @@ export default function ProjectContainer ({}) {
     store.setProject(selectedProject)
   }, [ selectedProject ])
 
-  if (!selectedProject) throw new Error('ERROR: could not find project')
+  if (!selectedProject) throw new Error('ERROR: couldn\'t find project')
 
   return (
     <>

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
 import fetchTalkSearchResults from '@src/helpers/fetchTalkSearchResults.js'
+import fetchDatabaseSearchResults from '@src/helpers/fetchDatabaseSearchResults.js'
 
 import SearchResult from './SearchResult.js'
 
@@ -18,6 +19,7 @@ function SearchResultsList ({
 
   useEffect(function () {
     fetchTalkSearchResults(projectId, query, setSearchResults)
+    fetchDatabaseSearchResults(projectId, query, (data) => { console.log('+++ data: ', data) })
   }, [ projectId, query ])
 
   return (
@@ -34,12 +36,12 @@ function SearchResultsList ({
         justify='center'
         wrap={true}
       >
-        {searchResults.map(sr => (
+        {searchResults.map(subjectId => (
           <SearchResult
-            subjectId={sr.taggable_id.toString()}
+            subjectId={subjectId}
             projectSlug={projectSlug}
             titleField={titleField}
-            key={sr.taggable_id}
+            key={subjectId}
           />
         ))}
       </Box>

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -3,7 +3,7 @@ import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
-import fetchTagSearchResults from '@src/helpers/fetchTagSearchResults.js'
+import fetchTalkSearchResults from '@src/helpers/fetchTalkSearchResults.js'
 
 import SearchResult from './SearchResult.js'
 
@@ -17,7 +17,7 @@ function SearchResultsList ({
   const [ searchResults, setSearchResults ] = useState([])
 
   useEffect(function () {
-    fetchTagSearchResults(projectId, query, setSearchResults)
+    fetchTalkSearchResults(projectId, query, setSearchResults)
   }, [ projectId, query ])
 
   return (

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -3,8 +3,7 @@ import { Box, Text } from 'grommet'
 import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
-import fetchTalkSearchResults from '@src/helpers/fetchTalkSearchResults.js'
-import fetchDatabaseSearchResults from '@src/helpers/fetchDatabaseSearchResults.js'
+import fetchSearchResults from '@src/helpers/fetchSearchResults.js'
 
 import SearchResult from './SearchResult.js'
 
@@ -18,8 +17,7 @@ function SearchResultsList ({
   const [ searchResults, setSearchResults ] = useState([])
 
   useEffect(function () {
-    fetchTalkSearchResults(projectId, query, setSearchResults)
-    fetchDatabaseSearchResults(projectId, query, (data) => { console.log('+++ data: ', data) })
+    fetchSearchResults(projectId, query, setSearchResults)
   }, [ projectId, query ])
 
   return (

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -11,14 +11,14 @@ function SearchResultsList ({
   query = '',
 }) {
   const store = useStores()
-  const projectId = store.project?.id
-  const projectSlug = store.project?.slug || ''
-  const titleField = store.project?.titleField || ''
+  const project = store.project
+  const projectSlug = project?.slug || ''
+  const titleField = project?.titleField || ''
   const [ searchResults, setSearchResults ] = useState([])
 
   useEffect(function () {
-    fetchSearchResults(projectId, query, setSearchResults)
-  }, [ projectId, query ])
+    if (project) fetchSearchResults(project, query, setSearchResults)
+  }, [ project, query ])
 
   return (
     <Box

--- a/src/components/Tester/Tester.js
+++ b/src/components/Tester/Tester.js
@@ -13,10 +13,10 @@ export default function Tester () {
 
   function formTester_onSubmit () {
     console.log('+++ SUBMITTED: ', query)
-    fetchTalkSearchResults(query)
+    fetchSearchResults_fromTalk(query)
   }
 
-  async function fetchTalkSearchResults (query) {
+  async function fetchSearchResults_fromTalk (query) {
     try {
       const response = await talkAPI.get('/searches', {
         section: 'zooniverse',
@@ -36,7 +36,7 @@ export default function Tester () {
     }
   }
 
-  async function fetchTalkSearchResults (query) {
+  async function fetchSearchResults_fromTalk (query) {
     // https://talk.zooniverse.org/tags/popular?http_cache=true&page=1&taggable_type=Subject&section=project-7929&name=flares
     try {
       const response = await talkAPI.get('/tags/popular', {

--- a/src/components/Tester/Tester.js
+++ b/src/components/Tester/Tester.js
@@ -13,7 +13,7 @@ export default function Tester () {
 
   function formTester_onSubmit () {
     console.log('+++ SUBMITTED: ', query)
-    fetchTagSearchResults(query)
+    fetchTalkSearchResults(query)
   }
 
   async function fetchTalkSearchResults (query) {
@@ -36,7 +36,7 @@ export default function Tester () {
     }
   }
 
-  async function fetchTagSearchResults (query) {
+  async function fetchTalkSearchResults (query) {
     // https://talk.zooniverse.org/tags/popular?http_cache=true&page=1&taggable_type=Subject&section=project-7929&name=flares
     try {
       const response = await talkAPI.get('/tags/popular', {

--- a/src/helpers/fetchDatabaseSearchResults.js
+++ b/src/helpers/fetchDatabaseSearchResults.js
@@ -1,0 +1,46 @@
+/*
+Fetches search results from the Subjects database. Specifically, it searches for TAGs
+(hashtags) in posts, for a specific project.
+
+Inputs:
+- (string/int) projectId
+- (object) query: contains keys with values to search for.
+  e.g. { colour: [ 'red', 'blue' ], shape: ['circle'], texture: ['%soft%'] }
+  becomes "SELECT * FROM whatever WHERE (colour = 'red' OR colour = 'blue') AND (shape = 'circle) AND (texture LIKE '%soft%')"
+- (function) setData: callback function after successful data fetch
+
+Outputs:
+- Array of subject IDs (strings)
+ */
+
+const DATABASE_URL = 'https://subject-set-search-api.zooniverse.org/'
+const DATABASE_NAME = 'projects'
+const TABLE_PREFIX = 'proj_'
+const SUBJECT_ID_KEY = 'subject_id'
+
+export default async function fetchDatabaseSearchResults (
+  projectId,
+  query = {},
+  setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
+) {
+  if (!projectId) return
+
+  // Example: https://subject-set-search-api.zooniverse.org/projects.json?sql=select+*+from+proj_21084+where+%5Bfolder%5D+like+%27%25jamaica%25%27
+  try {
+    const sqlQuery = `SELECT subject_id FROM ${TABLE_PREFIX}${projectId} WHERE true`
+    const url = `${DATABASE_URL}/${DATABASE_NAME}.json?sql=${encodeURIComponent(sqlQuery)}`
+
+    const response = await fetch(url)
+
+    if (!response?.ok) throw new Error('Couldn\'t fetch database search results')
+
+    let results =  await response.json()
+    const indexOfSubjectId = results?.columns?.indexOf(SUBJECT_ID_KEY)
+    results = results?.rows?.map(item => (item[indexOfSubjectId] || '').toString()) || []
+    setData(results)
+
+  } catch (err) {
+    console.error(err)
+    // TODO: handle errors
+  }
+}

--- a/src/helpers/fetchDatabaseSearchResults.js
+++ b/src/helpers/fetchDatabaseSearchResults.js
@@ -4,7 +4,7 @@ Fetches search results from the Subjects database. Specifically, it searches for
 
 Inputs:
 - (string/int) projectId
-- (object) query: contains keys with values to search for.
+- (object) queryObject: contains keys with values to search for.
   e.g. { colour: [ 'red', 'blue' ], shape: ['circle'], texture: ['%soft%'] }
   becomes "SELECT * FROM whatever WHERE (colour = 'red' OR colour = 'blue') AND (shape = 'circle) AND (texture LIKE '%soft%')"
 - (function) setData: callback function after successful data fetch
@@ -20,7 +20,7 @@ const SUBJECT_ID_KEY = 'subject_id'
 
 export default async function fetchDatabaseSearchResults (
   projectId,
-  query = {},
+  queryObject = {},
   setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
 ) {
   if (!projectId) return

--- a/src/helpers/fetchDatabaseSearchResults.js
+++ b/src/helpers/fetchDatabaseSearchResults.js
@@ -20,8 +20,7 @@ const SUBJECT_ID_KEY = 'subject_id'
 
 export default async function fetchDatabaseSearchResults (
   projectId,
-  queryObject = {},
-  setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
+  queryObject = {}
 ) {
   if (!projectId) return
 
@@ -36,11 +35,11 @@ export default async function fetchDatabaseSearchResults (
 
     let results =  await response.json()
     const indexOfSubjectId = results?.columns?.indexOf(SUBJECT_ID_KEY)
-    results = results?.rows?.map(item => (item[indexOfSubjectId] || '').toString()) || []
-    setData(results)
+    return results?.rows?.map(item => (item[indexOfSubjectId] || '').toString()) || []
 
   } catch (err) {
     console.error(err)
+    throw(err)
     // TODO: handle errors
   }
 }

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -37,7 +37,12 @@ export default async function fetchSearchResults (
 }
 
 function convertQueryStringToQueryObject (project, query = '') {
+  if (!project) return {}
+
   const queryObject = {}
+  project.metadata_fields.map(field => (
+    queryObject[field] = [`%${query}%`]
+  ))
 
   return queryObject
 }

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -2,7 +2,7 @@
 Fetches search results from both Zooniverse Talk and the Subjects database.
 
 Inputs:
-- (string/int) projectId
+- (object) project: project config object (see projects.json)
 - (string) query
   e.g. to search for Talk posts tagged with "#penguins", pass in queryString="penguins"
 - (function) setData: callback function after successful data fetch
@@ -15,21 +15,29 @@ import fetchSearchResults_fromTalk from './fetchSearchResults_fromTalk.js'
 import fetchSearchResults_fromDatabase from './fetchSearchResults_fromDatabase.js'
 
 export default async function fetchSearchResults (
-  projectId,
+  project,
   query = '',
   setData = (data) => { console.log('fetchSearchResults_fromTalk: ', data) }
 ) {
 
+  if (!project) throw new Error('fetchSearchResults() requires a project')
+  
   const queryString = query
-  const queryObject = {}
+  const queryObject = convertQueryStringToQueryObject(project, query)
 
   const allSubjectIds = await Promise.all([
-    fetchSearchResults_fromTalk(projectId, queryString),
-    fetchSearchResults_fromDatabase(projectId, queryObject)
+    fetchSearchResults_fromTalk(project.id, queryString),
+    fetchSearchResults_fromDatabase(project.id, queryObject)
   ])
 
   // Flatten into a single array, then remove duplicates
   const subjectIds = Array.from(new Set(allSubjectIds.flat()))
 
   setData(subjectIds)
+}
+
+function convertQueryStringToQueryObject (project, query = '') {
+  const queryObject = {}
+
+  return queryObject
 }

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -12,21 +12,21 @@ Outputs:
 - Array of subject IDs (strings)
  */
 
-import fetchTalkSearchResults from './fetchTalkSearchResults.js'
-import fetchDatabaseSearchResults from './fetchDatabaseSearchResults.js'
+import fetchSearchResults_fromTalk from './fetchSearchResults_fromTalk.js'
+import fetchSearchResults_fromDatabase from './fetchSearchResults_fromDatabase.js'
 
 export default async function fetchSearchResults (
   projectId,
   query = '',
-  setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
+  setData = (data) => { console.log('fetchSearchResults_fromTalk: ', data) }
 ) {
 
   const queryString = query
   const queryObject = {}
 
   const allSubjectIds = await Promise.all([
-    fetchTalkSearchResults(projectId, queryString),
-    fetchDatabaseSearchResults(projectId, queryObject)
+    fetchSearchResults_fromTalk(projectId, queryString),
+    fetchSearchResults_fromDatabase(projectId, queryObject)
   ])
 
   // Flatten into a single array, then remove duplicates

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -1,0 +1,36 @@
+/*
+Fetches search results from Zooniverse Talk. Specifically, it searches for TAGs
+(hashtags) in posts, for a specific project.
+
+Inputs:
+- (string/int) projectId
+- (string) query
+  e.g. to search for Talk posts tagged with "#penguins", pass in queryString="penguins"
+- (function) setData: callback function after successful data fetch
+
+Outputs:
+- Array of subject IDs (strings)
+ */
+
+import fetchTalkSearchResults from './fetchTalkSearchResults.js'
+import fetchDatabaseSearchResults from './fetchDatabaseSearchResults.js'
+
+export default async function fetchSearchResults (
+  projectId,
+  query = '',
+  setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
+) {
+
+  const queryString = query
+  const queryObject = {}
+
+  const allSubjectIds = await Promise.all([
+    fetchTalkSearchResults(projectId, queryString),
+    fetchDatabaseSearchResults(projectId, queryObject)
+  ])
+
+  // Flatten into a single array, then remove duplicates
+  const subjectIds = Array.from(new Set(allSubjectIds.flat()))
+
+  setData(subjectIds)
+}

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -1,6 +1,5 @@
 /*
-Fetches search results from Zooniverse Talk. Specifically, it searches for TAGs
-(hashtags) in posts, for a specific project.
+Fetches search results from both Zooniverse Talk and the Subjects database.
 
 Inputs:
 - (string/int) projectId
@@ -9,7 +8,7 @@ Inputs:
 - (function) setData: callback function after successful data fetch
 
 Outputs:
-- Array of subject IDs (strings)
+- Array of unique subject IDs (strings)
  */
 
 import fetchSearchResults_fromTalk from './fetchSearchResults_fromTalk.js'

--- a/src/helpers/fetchSearchResults_fromDatabase.js.js
+++ b/src/helpers/fetchSearchResults_fromDatabase.js.js
@@ -22,7 +22,7 @@ export default async function fetchSearchResults_fromDatabase (
   projectId,
   queryObject = {}
 ) {
-  if (!projectId) return
+  if (!projectId) return []
 
   // Example: https://subject-set-search-api.zooniverse.org/projects.json?sql=select+*+from+proj_21084+where+%5Bfolder%5D+like+%27%25jamaica%25%27
   try {

--- a/src/helpers/fetchSearchResults_fromDatabase.js.js
+++ b/src/helpers/fetchSearchResults_fromDatabase.js.js
@@ -18,7 +18,7 @@ const DATABASE_NAME = 'projects'
 const TABLE_PREFIX = 'proj_'
 const SUBJECT_ID_KEY = 'subject_id'
 
-export default async function fetchDatabaseSearchResults (
+export default async function fetchSearchResults_fromDatabase (
   projectId,
   queryObject = {}
 ) {

--- a/src/helpers/fetchSearchResults_fromTalk.js
+++ b/src/helpers/fetchSearchResults_fromTalk.js
@@ -18,7 +18,7 @@ export default async function fetchSearchResults_fromTalk (
   projectId,
   queryString = ''
 ) {
-  if (!projectId) return
+  if (!projectId) return []
 
   // Example: https://talk.zooniverse.org/tags/popular?http_cache=true&page=1&taggable_type=Subject&section=project-7929&name=flares
   try {

--- a/src/helpers/fetchSearchResults_fromTalk.js
+++ b/src/helpers/fetchSearchResults_fromTalk.js
@@ -14,7 +14,7 @@ Outputs:
 
 import { talkAPI } from '@zooniverse/panoptes-js'
 
-export default async function fetchTalkSearchResults (
+export default async function fetchSearchResults_fromTalk (
   projectId,
   queryString = ''
 ) {

--- a/src/helpers/fetchTalkSearchResults.js
+++ b/src/helpers/fetchTalkSearchResults.js
@@ -1,9 +1,23 @@
+/*
+Fetches search results from Zooniverse Talk. Specifically, it searches for TAGs
+(hashtags) in posts, for a specific project.
+
+Inputs:
+- (string/int) projectId
+- (string) query: tag/hashtag to search for.
+  e.g. to search for Talk posts tagged with "#penguins", pass in query="penguins"
+- (function) setData: callback function after successful data fetch
+
+Outputs:
+- Array of Talk posts (Panoptes resource)
+ */
+
 import { talkAPI } from '@zooniverse/panoptes-js'
 
-export default async function fetchTagSearchResults (
+export default async function fetchTalkSearchResults (
   projectId,
   query = '',
-  setData = (data) => { console.log('fetchTagSearchResults: ', data) }
+  setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
 ) {
   if (!projectId) return
 

--- a/src/helpers/fetchTalkSearchResults.js
+++ b/src/helpers/fetchTalkSearchResults.js
@@ -16,8 +16,7 @@ import { talkAPI } from '@zooniverse/panoptes-js'
 
 export default async function fetchTalkSearchResults (
   projectId,
-  queryString = '',
-  setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
+  queryString = ''
 ) {
   if (!projectId) return
 
@@ -34,11 +33,11 @@ export default async function fetchTalkSearchResults (
     if (!response?.ok) throw new Error('Couldn\'t fetch Talk search results')
 
     let results = response.body?.popular || []
-    results = results.map(item => item.taggable_id?.toString() || '')
-    setData(results)
+    return results.map(item => item.taggable_id?.toString() || '') || []
 
   } catch (err) {
     console.error(err)
+    throw(err)
     // TODO: handle errors
   }
 }

--- a/src/helpers/fetchTalkSearchResults.js
+++ b/src/helpers/fetchTalkSearchResults.js
@@ -9,7 +9,7 @@ Inputs:
 - (function) setData: callback function after successful data fetch
 
 Outputs:
-- Array of Talk posts (Panoptes resource)
+- Array of subject IDs (strings)
  */
 
 import { talkAPI } from '@zooniverse/panoptes-js'
@@ -31,9 +31,10 @@ export default async function fetchTalkSearchResults (
       name: query
     })
 
-    if (!response?.ok) throw new Error('Couldn\'t fetch tag search results')
+    if (!response?.ok) throw new Error('Couldn\'t fetch Talk search results')
 
-    const results = response.body?.popular || []
+    let results = response.body?.popular || []
+    results = results.map(item => item.taggable_id?.toString() || '')
     setData(results)
 
   } catch (err) {

--- a/src/helpers/fetchTalkSearchResults.js
+++ b/src/helpers/fetchTalkSearchResults.js
@@ -4,8 +4,8 @@ Fetches search results from Zooniverse Talk. Specifically, it searches for TAGs
 
 Inputs:
 - (string/int) projectId
-- (string) query: tag/hashtag to search for.
-  e.g. to search for Talk posts tagged with "#penguins", pass in query="penguins"
+- (string) queryString: tag/hashtag to search for.
+  e.g. to search for Talk posts tagged with "#penguins", pass in queryString="penguins"
 - (function) setData: callback function after successful data fetch
 
 Outputs:
@@ -16,7 +16,7 @@ import { talkAPI } from '@zooniverse/panoptes-js'
 
 export default async function fetchTalkSearchResults (
   projectId,
-  query = '',
+  queryString = '',
   setData = (data) => { console.log('fetchTalkSearchResults: ', data) }
 ) {
   if (!projectId) return
@@ -28,7 +28,7 @@ export default async function fetchTalkSearchResults (
       taggable_type: 'Subject',
       page: 1,
       page_size: 20,
-      name: query
+      name: queryString
     })
 
     if (!response?.ok) throw new Error('Couldn\'t fetch Talk search results')

--- a/src/pages/HomePage/index.js
+++ b/src/pages/HomePage/index.js
@@ -1,1 +1,0 @@
-export { default } from './HomePage.js'

--- a/src/pages/ProjectPage/ProjectPage.js
+++ b/src/pages/ProjectPage/ProjectPage.js
@@ -9,7 +9,7 @@ import SearchResultsList from '@src/components/SearchResultsList'
 import KeywordsList from '@src/components/KeywordsList'
 import getQuery from '@src/helpers/getQuery'
 
-function HomePage () {
+function ProjectPage () {
   const store = useStores()
   const projectSlug = store.project?.slug || ''
   const exampleSubjects = store.project?.exampleSubjects || []
@@ -59,4 +59,4 @@ function HomePage () {
   )
 }
 
-export default observer(HomePage)
+export default observer(ProjectPage)

--- a/src/pages/ProjectPage/index.js
+++ b/src/pages/ProjectPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ProjectPage.js'

--- a/src/router.js
+++ b/src/router.js
@@ -2,7 +2,7 @@ import { createBrowserRouter } from 'react-router-dom'
 import App from '@src/App'
 
 import ProjectContainer from '@src/components/ProjectContainer'
-import HomePage from '@src/pages/HomePage'
+import ProjectPage from '@src/pages/ProjectPage'
 import SearchPage from '@src/pages/SearchPage'
 import SubjectPage from '@src/pages/SubjectPage'
 import Tester from '@src/components/Tester'
@@ -19,7 +19,7 @@ export const router = createBrowserRouter([
         children: [
           {
             path: '',
-            element: <HomePage />,
+            element: <ProjectPage />,
           },
           {
             path: 'search',


### PR DESCRIPTION
## PR Overview

This PR adds _database search functionality_ to the Community Catalog.

- New behaviour:
  - when typing in a search query, the CC now searches both **Talk** and the (Subject Set Search API) **Database**
- Code changes:
  - fetchSearchResults() now consolidates the fetch actions, and removes duplicates. Oh, also we only care about getting Subject IDs, not the full resources.
  - fetchTalkSearchResults() and fetchDatabaseResults() renamed.
  - HomePage renamed to ProjectPage. We still need a root home page.
- ⚠️ Pagination hasn't come up yet, but will become an issue once we have a larger amount of Subjects.

### Status

Ready to go!