### PR TITLE
Home Page and misc updates

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -40,9 +40,6 @@ export default function App () {
             <Box size='small' border={true}>
               <Heading as='h6'>Debug Panel</Heading>
               <P size='small'>{(store.user) ? `Logged in as ${store.user.display_name || store.user.login}` : 'User isn\'t logged in'}</P>
-              <Box size='small' as='nav' direction='row'>
-                <Link to='/'>Home Page</Link> | <Link to='/search'>Search Page</Link> | <Link to='/subject/12345'>Subject Page</Link>
-              </Box>
             </Box>
           </Box> :
           <P>Initialising...</P>

--- a/src/components/KeywordsList/KeywordsList.js
+++ b/src/components/KeywordsList/KeywordsList.js
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { Box, Text } from 'grommet'
 import styled from 'styled-components'
 import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
 import fetchKeywords from '@src/helpers/fetchKeywords.js'
+import Link from '@src/components/Link'
 
 const KeywordLink = styled(Link)`
   text-decoration: none;

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -11,7 +11,9 @@ export default function Link ({ to, children }) {
 
   if (!to.includes('?')) toUrl.push('?')
   if (env) toUrl.push(`&env=${encodeURIComponent(env)}`)
-  if (query) toUrl.push(`&env=${encodeURIComponent(query)}`)
+
+  // Keep the query consistent, if the intended URL doesn't already have its own query
+  if (query && !to.match(/[\?&]env=/ig)) toUrl.push(`&env=${encodeURIComponent(query)}`)
   
   return (
     <BaseLink

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -3,7 +3,12 @@ import { Link as BaseLink } from 'react-router-dom'
 import getEnv from '@src/helpers/getEnv'
 import getQuery from '@src/helpers/getQuery'
 
-export default function Link ({ to, children }) {
+export default function Link (props) {
+  const { to, children } = props
+
+  const otherProps = { ...props }
+  otherProps.to && delete otherProps.to
+  otherProps.children && delete otherProps.children
   
   const toUrl = [ to ]
   const env = getEnv()
@@ -18,6 +23,7 @@ export default function Link ({ to, children }) {
   return (
     <BaseLink
       to={toUrl.join('')}
+      {...otherProps}
     >
       {children}
     </BaseLink>

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -1,0 +1,23 @@
+import { Link as BaseLink } from 'react-router-dom'
+
+import getEnv from '@src/helpers/getEnv'
+import getQuery from '@src/helpers/getQuery'
+
+export default function Link ({ to, children }) {
+  
+  const toUrl = [ to ]
+  const env = getEnv()
+  const query = getQuery()
+
+  if (!to.includes('?')) toUrl.push('?')
+  if (env) toUrl.push(`&env=${encodeURIComponent(env)}`)
+  if (query) toUrl.push(`&env=${encodeURIComponent(query)}`)
+  
+  return (
+    <BaseLink
+      to={toUrl.join('')}
+    >
+      {children}
+    </BaseLink>
+  )
+}

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -18,7 +18,7 @@ export default function Link (props) {
   if (env) toUrl.push(`&env=${encodeURIComponent(env)}`)
 
   // Keep the query consistent, if the intended URL doesn't already have its own query
-  if (query && !to.match(/[\?&]env=/ig)) toUrl.push(`&env=${encodeURIComponent(query)}`)
+  if (query && !to.match(/[\?&]query=/ig)) toUrl.push(`&query=${encodeURIComponent(query)}`)
   
   return (
     <BaseLink

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,0 +1,1 @@
+export { default } from './Link.js'

--- a/src/components/SearchResultsList/SearchResult.js
+++ b/src/components/SearchResultsList/SearchResult.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
-import { Link } from 'react-router-dom'
 
+import Link from '@src/components/Link'
 import SubjectImage from '@src/components/SubjectImage'
 import fetchSubject from '@src/helpers/fetchSubject.js'
 

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -27,7 +27,7 @@ function SearchResultsList ({
       pad='small'
       gap='small'
     >
-      <Text>Results for the tag "{query}" on Talk:</Text>
+      <Text>Search results for "{query}":</Text>
       <Box
         direction='row'
         gap='medium'

--- a/src/components/SubjectImage/SubjectImage.js
+++ b/src/components/SubjectImage/SubjectImage.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Box, Image } from 'grommet'
+import { Box, Image, Spinner } from 'grommet'
+import { Image as ImageIcon } from 'grommet-icons'
 import fetchSubject from '@src/helpers/fetchSubject'
 
 export default function SubjectImage ({
@@ -34,19 +35,25 @@ export default function SubjectImage ({
     }
   }
 
-  if (!imgSrc) imgSrc = 'https://placekitten.com/g/200/200'  // TODO: placeholder 
-  
   return (
     <Box
       background='light-1'
       border={true}
       width={`${width}px`}
-      height={`${height}px`} 
+      height={`${height}px`}
+      align={imgSrc ? undefined : 'center'} 
+      justify={imgSrc ? undefined : 'center'} 
     >
-      <Image
-        fit={fit || (small ? 'cover' : 'contain')}
-        src={imgSrc}
-      />
+      {imgSrc ? (
+        <Image
+          fit={fit || (small ? 'cover' : 'contain')}
+          src={imgSrc}
+        />
+      ) : (  /* Placeholder when there's no image to load, or Subject is in process of loading */
+        <ImageIcon
+          size='large'
+        />
+      )}
     </Box>
   )
 }

--- a/src/components/SubjectImage/SubjectImage.js
+++ b/src/components/SubjectImage/SubjectImage.js
@@ -26,10 +26,11 @@ export default function SubjectImage ({
   
   let imgSrc = src
   if (subjectData) {
-      // TODO: improve URL extraction
+    // TODO: improve URL extraction
     imgSrc = subjectData.locations?.[0]?.['image/jpeg']
              || subjectData.locations?.[0]?.['image/png']
 
+    // Send Zooniverse-hosted images through the thumbnail service
     if (small && imgSrc.match(/^https?:\/\/panoptes-uploads.zooniverse.org\//)) {
       imgSrc = `https://thumbnails.zooniverse.org/${width}x${height}/${imgSrc?.replace(/^https?:\/\//ig, '')}`
     }

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -14,7 +14,9 @@ function SubjectKeywords ({
   subject = undefined,
 }) {
   const store = useStores()
-  const projectId = store.project?.id
+  const project = store.project
+  const projectId = project?.id
+  const projectSlug = project?.slug || '' 
 
   const [ keywordsData, setKeywordsData ] = useState([])
 
@@ -43,7 +45,7 @@ function SubjectKeywords ({
         {keywordsData.map((keyword, i) => (
           <KeywordLink
             key={`subject-keyword-${i}`}
-            to={`/search?query=${encodeURIComponent(keyword.name)}`}
+            to={`/projects/${projectSlug}/search?query=${encodeURIComponent(keyword.name)}`}
           >
             <Box
               background='light-2'

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
 import { Box, Text } from 'grommet'
-import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
 import fetchKeywords from '@src/helpers/fetchKeywords'
+import Link from '@src/components/Link'
 
 const KeywordLink = styled(Link)`
   text-decoration: none;

--- a/src/components/SubjectMetadata/SubjectMetadata.js
+++ b/src/components/SubjectMetadata/SubjectMetadata.js
@@ -1,8 +1,8 @@
 import { Box, Table, TableBody, TableCell, TableRow, Text } from 'grommet'
-import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 
 import fetchKeywords from '@src/helpers/fetchKeywords'
+import Link from '@src/components/Link'
 
 const KeywordLink = styled(Link)`
   text-decoration: none;

--- a/src/helpers/getEnv.js
+++ b/src/helpers/getEnv.js
@@ -1,7 +1,7 @@
-export default function getQuery () {
+export default function getEnv () {
   try {
     const param = new URLSearchParams(window?.location?.search)
-    return param.get('query') || undefined
+    return param.get('env') || undefined
   } catch (err) {
     return undefined
   }

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -1,6 +1,6 @@
 import { Box } from 'grommet'
-import Link from '@src/components/Link'
 
+import Link from '@src/components/Link'
 import projectsJson from '@src/projects.json'
 
 function HomePage () {

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -1,5 +1,5 @@
 import { Box } from 'grommet'
-import { Link } from 'react-router-dom'
+import Link from '@src/components/Link'
 
 import projectsJson from '@src/projects.json'
 
@@ -12,6 +12,7 @@ function HomePage () {
     >
       {projectsJson.projects.map(proj => (
         <Box
+          key={`project-${proj.id}`}
           background='light-1'
           pad='small'
         >

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -1,0 +1,25 @@
+import { Box } from 'grommet'
+import { Link } from 'react-router-dom'
+
+import projectsJson from '@src/projects.json'
+
+function HomePage () {
+  return (
+    <Box
+      background='dark-1'
+      gap='small'
+      pad='small'
+    >
+      {projectsJson.projects.map(proj => (
+        <Box
+          background='light-1'
+          pad='small'
+        >
+          <Link to={`/projects/${proj.slug}`}>{proj.name}</Link>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export default HomePage

--- a/src/pages/HomePage/index.js
+++ b/src/pages/HomePage/index.js
@@ -1,0 +1,1 @@
+export { default } from './HomePage.js'

--- a/src/pages/ProjectPage/ProjectPage.js
+++ b/src/pages/ProjectPage/ProjectPage.js
@@ -1,9 +1,9 @@
 import { useEffect } from 'react'
 import { Box, Button, Carousel, Text } from 'grommet'
-import { Link } from 'react-router-dom'
 import { observer } from 'mobx-react'
 
 import { useStores } from '@src/store'
+import Link from '@src/components/Link'
 import SubjectImage from '@src/components/SubjectImage'
 import SearchResultsList from '@src/components/SearchResultsList'
 import KeywordsList from '@src/components/KeywordsList'

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -19,7 +19,8 @@ export default function SubjectPage () {
 
   useEffect(function () {
     fetchSubject(subjectId, setSubjectData)
-  }, [])
+    window.scrollTo(0, 0)
+  }, [ subjectId ])
 
   return (
     <>

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom'
 import App from '@src/App'
 
+import HomePage from '@src/pages/HomePage'
 import ProjectContainer from '@src/components/ProjectContainer'
 import ProjectPage from '@src/pages/ProjectPage'
 import SearchPage from '@src/pages/SearchPage'
@@ -13,6 +14,10 @@ export const router = createBrowserRouter([
     element: <App />,
     errorElement: <h1>Unspecified Error</h1>,
     children: [
+      {
+        path: '',
+        element: <HomePage />,
+      },
       {
         path: '/projects/:projectOwner/:projectName',
         element: <ProjectContainer />,


### PR DESCRIPTION
## PR Overview

Originally, this PR was just going to add a rudimentary Home Page to the root route, but it's since expanded to roll in a bunch of fixes and updates.

- New components & features:
  - Home Page: added to `/` route
  - Link wrapper: ensures links preserve `?env` and `?query` parameters
- Updated components & features:
  - SubjectImage: placeholder kittens replaced with a generic placeholder icon of an image. It's sad, I know.
  - (minor) SearchResultsList: text changed to no longer only refer to Talk tags. (Search now hits the database _and_ Talk tags)
- Other:
  - Debug panel removed from `<App>`