### PR TITLE
Advanced Search

### DIFF
--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 
 import strings from '@src/strings.json'
-import { ADVANCED_QUERY_PREFIX, KEYWORDS_KEY } from '@src/config.js'
+import { KEYWORDS_KEY } from '@src/config.js'
 import getEnv from '@src/helpers/getEnv.js'
 import convertAdvancedQueryFromString from '@src/helpers/convertAdvancedQueryFromString.js'
 import convertAdvancedQueryToString from '@src/helpers/convertAdvancedQueryToString.js'
@@ -24,12 +24,13 @@ export default function AdvancedSearchForm ({ project }) {
   // navigating to the same /search route won't automatically re-render the
   // component.
   function onSubmit ({ value: data }) {
+    console.log('+++ data: ', data)
     const query = convertAdvancedQueryToString(data)
     console.log('+++ query: ', query)
     const testData = convertAdvancedQueryFromString(query)
     console.log('+++ testData: ', testData)
 
-    navigate(`/projects/${projectSlug}/search?query=${encodeURIComponent(query)}`)
+    navigate(`/projects/${projectSlug}/search?query=${encodeURIComponent(query)}${(env) ? `&env=${encodeURIComponent(env)}` : ''}`)
   }
 
   return (
@@ -43,10 +44,10 @@ export default function AdvancedSearchForm ({ project }) {
         <Box>
           <Box>
             <Text as='label' htmlFor='tag'>{strings.components.advanced_search.keywords_label}</Text>
-            <InputForText name={`${ADVANCED_QUERY_PREFIX}${KEYWORDS_KEY}`} />
+            <InputForText name={`${KEYWORDS_KEY}`} />
           </Box>
           {project.advanced_search?.map(item => {
-            const name = `${ADVANCED_QUERY_PREFIX}${item.field}`
+            const name = `${item.field}`
             const display = item.alias || item.field
             
             return (

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -3,38 +3,15 @@ import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 
 import strings from '@src/strings.json'
-import { ADVANCED_QUERY_PREFIX } from '@src/config.js'
+import { ADVANCED_QUERY_PREFIX, KEYWORDS_KEY } from '@src/config.js'
 import getEnv from '@src/helpers/getEnv.js'
+import convertAdvancedQueryFromString from '@src/helpers/convertAdvancedQueryFromString.js'
+import convertAdvancedQueryToString from '@src/helpers/convertAdvancedQueryToString.js'
 
 const InputForText = styled(TextInput)`
   background: white;
   color: black;
 `
-
-// Example: { one: 'abc', two: '', three: '===' } should return "{one=abc} {three====}"
-// Assumption: keys don't contain '='
-function convertAdvancedQueryToString (data) {
-  return Object.entries(data).map(([key, val = '']) => {
-    const _key = key.replace(RegExp(`^${ADVANCED_QUERY_PREFIX}`), '')
-    const _val = val.trim()  // TODO: what if val has { or } ?
-    return (_val)
-      ? `{${_key}=${_val}}`
-      : ''
-  }).join(' ')
-}
-
-// Example: "{one=abc} {two=} {three====}" should return { one: 'abc', three: '===' }
-// Assumption: keys don't contain '='
-function convertAdvancedQueryFromString (str = '') {
-  const data = {}
-  str.match(/{[^{}=]+=[^{}]*}/g)?.forEach(item => {
-    const match = item.match(/^{([^=]+)=(.*)}$/)  // Don't use global (g)
-    if (match?.[1] && match?.[2]) {  // match[1] is the key, match[2] is the value
-      data[match[1]] = match[2]
-    }
-  })
-  return data
-}
 
 export default function AdvancedSearchForm ({ project }) {
   if (!project) return null
@@ -65,8 +42,8 @@ export default function AdvancedSearchForm ({ project }) {
       >
         <Box>
           <Box>
-            <Text as='label' htmlFor='query'>DEBUG QUERY</Text>
-            <InputForText name='query' />
+            <Text as='label' htmlFor='tag'>{strings.components.advanced_search.keywords_label}</Text>
+            <InputForText name={`${ADVANCED_QUERY_PREFIX}${KEYWORDS_KEY}`} />
           </Box>
           {project.advanced_search?.map(item => {
             const name = `${ADVANCED_QUERY_PREFIX}${item.field}`

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -29,12 +29,7 @@ export default function AdvancedSearchForm ({ project }) {
   // navigating to the same /search route won't automatically re-render the
   // component.
   function onSubmit ({ value: data }) {
-    console.log('+++ data: ', data)
     const query = convertAdvancedQueryToString(data)
-    console.log('+++ query: ', query)
-    const testData = convertAdvancedQueryFromString(query)
-    console.log('+++ testData: ', testData)
-
     navigate(`/projects/${projectSlug}/search?query=${encodeURIComponent(query)}${(env) ? `&env=${encodeURIComponent(env)}` : ''}`)
   }
 

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -49,7 +49,7 @@ export default function AdvancedSearchForm ({ project }) {
         <Box>
           <Box>
             <Text as='label' htmlFor='tag'>{strings.components.advanced_search.keywords_label}</Text>
-            <InputForText name={`${KEYWORDS_KEY}`} defaultValue={initialValues[KEYWORDS_KEY]} />
+            <InputForText name={`${KEYWORDS_KEY}`} />
           </Box>
           {project.advanced_search?.map(item => {
             const name = `${item.field}`
@@ -59,13 +59,13 @@ export default function AdvancedSearchForm ({ project }) {
             return (
               <Box key={name}>
                 <Text as='label' htmlFor={name}>{display}</Text>
-                <InputForText name={name} defaultValue={defaultValue} />
+                <InputForText name={name} />
               </Box>
             )
           })}
         </Box>
         <Box>
-          <button type='submit'>TEST</button>
+          <button type='submit'>SUBMIT</button>
         </Box>
       </Form>
     </Box>

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -11,6 +11,10 @@ const InputForText = styled(TextInput)`
   color: black;
 `
 
+function convertAdvancedQueryToString (data) {
+  
+}
+
 export default function AdvancedSearchForm ({ project }) {
   if (!project) return null
   const projectSlug = project.slug
@@ -28,7 +32,7 @@ export default function AdvancedSearchForm ({ project }) {
         .filter(([ key, val ]) => !!val)
         .map(([ key, val ]) => `${key}=${encodeURIComponent(val)}`)
     ]
-    navigate(`/projects/${projectSlug}/search?${params.join('&')}`, { replace: true })
+    navigate(`/projects/${projectSlug}/search?${params.join('&')}`)
   }
 
   return (

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -1,0 +1,13 @@
+import { Box } from 'grommet'
+
+import strings from '@src/strings.json'
+
+export default function AdvancedSearchForm ({ project }) {
+  if (!project) return null
+
+  return (
+    <Box>
+      Advanced Search
+    </Box>
+  )
+}

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -1,13 +1,65 @@
-import { Box } from 'grommet'
+import { Box, Form, Text, TextInput } from 'grommet'
+import styled from 'styled-components'
+import { useNavigate } from 'react-router-dom'
 
 import strings from '@src/strings.json'
+import { ADVANCED_QUERY_PREFIX } from '@src/config.js'
+import getEnv from '@src/helpers/getEnv.js'
+
+const InputForText = styled(TextInput)`
+  background: white;
+  color: black;
+`
 
 export default function AdvancedSearchForm ({ project }) {
   if (!project) return null
+  const projectSlug = project.slug
+  const env = getEnv()
+  const navigate = useNavigate()
+
+  // Submit the advanced search query
+  // Note that the parent SearchPage has to listen for changes in the URL, since
+  // navigating to the same /search route won't automatically re-render the
+  // component.
+  function onSubmit ({ value: data }) {
+    const params = [
+      `env=${encodeURIComponent(env)}`,
+      ...Object.entries(data)
+        .filter(([ key, val ]) => !!val)
+        .map(([ key, val ]) => `${key}=${encodeURIComponent(val)}`)
+    ]
+    navigate(`/projects/${projectSlug}/search?${params.join('&')}`, { replace: true })
+  }
 
   return (
-    <Box>
-      Advanced Search
+    <Box
+      pad='small'
+      gap='small'
+    >
+      <Form
+        onSubmit={onSubmit}
+      >
+        <Box>
+          <Box>
+            <Text as='label' htmlFor='query'>DEBUG QUERY</Text>
+            <InputForText name='query' />
+          </Box>
+          {project.advanced_search?.map(item => {
+            const name = `${ADVANCED_QUERY_PREFIX}${item.field}`
+            const display = item.alias || item.field
+            
+            return (
+              <Box key={name}>
+                <Text as='label' htmlFor={name}>{display}</Text>
+                <InputForText name={name} />
+              </Box>
+            )
+          })}
+        </Box>
+        <Box>
+          <button type='submit'>TEST</button>
+        </Box>
+      </Form>
     </Box>
   )
 }

--- a/src/components/AdvancedSearchForm/AdvancedSearchForm.js
+++ b/src/components/AdvancedSearchForm/AdvancedSearchForm.js
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import strings from '@src/strings.json'
 import { KEYWORDS_KEY } from '@src/config.js'
 import getEnv from '@src/helpers/getEnv.js'
+import getQuery from '@src/helpers/getQuery.js'
 import convertAdvancedQueryFromString from '@src/helpers/convertAdvancedQueryFromString.js'
 import convertAdvancedQueryToString from '@src/helpers/convertAdvancedQueryToString.js'
 
@@ -18,6 +19,10 @@ export default function AdvancedSearchForm ({ project }) {
   const projectSlug = project.slug
   const env = getEnv()
   const navigate = useNavigate()
+
+  // Only relevant when the component loads for the first time
+  const initialQuery = getQuery()
+  const initialValues = convertAdvancedQueryFromString(initialQuery)
 
   // Submit the advanced search query
   // Note that the parent SearchPage has to listen for changes in the URL, since
@@ -44,16 +49,17 @@ export default function AdvancedSearchForm ({ project }) {
         <Box>
           <Box>
             <Text as='label' htmlFor='tag'>{strings.components.advanced_search.keywords_label}</Text>
-            <InputForText name={`${KEYWORDS_KEY}`} />
+            <InputForText name={`${KEYWORDS_KEY}`} defaultValue={initialValues[KEYWORDS_KEY]} />
           </Box>
           {project.advanced_search?.map(item => {
             const name = `${item.field}`
             const display = item.alias || item.field
+            const defaultValue = initialValues[name]
             
             return (
               <Box key={name}>
                 <Text as='label' htmlFor={name}>{display}</Text>
-                <InputForText name={name} />
+                <InputForText name={name} defaultValue={defaultValue} />
               </Box>
             )
           })}

--- a/src/components/AdvancedSearchForm/index.js
+++ b/src/components/AdvancedSearchForm/index.js
@@ -1,0 +1,1 @@
+export { default } from './AdvancedSearchForm.js'

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -7,6 +7,7 @@ import { observer } from 'mobx-react'
 
 import strings from '@src/strings.json'
 import { useStores } from '@src/store'
+import getEnv from '@src/helpers/getEnv.js'
 
 const LogoLink = styled(Link)`
   color: #e2e5e9;
@@ -44,6 +45,7 @@ function Header () {
   const projectSlug = store.project?.slug || ''
   const projectURL = `https://www.zooniverse.org/projects/${projectSlug}`
   const talkURL = `https://www.zooniverse.org/projects/${projectSlug}/talk`
+  const env = getEnv()
 
   if (!store.project) return (
     <Box
@@ -120,6 +122,10 @@ function Header () {
           name='query'
           icon={<Search size='small' />}
         />
+        {(env)
+          ? <input name='env' value={env} type='hidden' />
+          : null
+        }
       </HeaderSearchForm>
     </Box>
   )

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -14,7 +14,7 @@ export default function Link (props) {
   if (env) toUrl.push(`&env=${encodeURIComponent(env)}`)
 
   // Keep the query consistent, if the intended URL doesn't already have its own query
-  if (query && !to.match(/[\?&]query=/ig)) toUrl.push(`&query=${encodeURIComponent(query)}`)
+  if (query && !to?.match(/[\?&]query=/ig)) toUrl.push(`&query=${encodeURIComponent(query)}`)
   
   return (
     <BaseLink

--- a/src/components/RandomButton/RandomButton.js
+++ b/src/components/RandomButton/RandomButton.js
@@ -8,7 +8,7 @@ It is not, in fact, a randomly created button.
  */
 
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom'
 import { Button } from 'grommet'
 
 import strings from '@src/strings.json'
@@ -34,7 +34,7 @@ export default function RandomButton ({
       if (subjectId) {
         const env = getEnv()
         navigate(`/projects/${project.slug}/subject/${subjectId}${
-          (env) ? `?env=${env}` : ''
+          (env) ? `?env=${encodeURIComponent(env)}` : ''
         }`)
       } else {
         throw new Error ('No Subjects available, apparently. Check database table isn\'t empty.')

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -27,7 +27,11 @@ function SearchResultsList ({
       pad='small'
       gap='small'
     >
-      <Text>{strings.components.search_results_list.search_results.replace(/{query}/g, query)}</Text>
+      <Text>{
+        (query)
+        ? strings.components.search_results_list.search_results.replace(/{query}/g, query)
+        : strings.components.search_results_list.search_results_all  /* No query, so show all results */
+      }</Text>
       <Box
         direction='row'
         gap='medium'

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -24,7 +24,6 @@ function SearchResultsList ({
   return (
     <Box
       background='light-1'
-      border={true}
       pad='small'
       gap='small'
     >

--- a/src/config.js
+++ b/src/config.js
@@ -2,5 +2,6 @@ export const DATABASE_URL = 'https://subject-set-search-api.zooniverse.org/'
 export const DATABASE_NAME = 'projects'
 export const TABLE_PREFIX = 'proj_'
 export const SUBJECT_ID_KEY = 'subject_id'
+export const KEYWORDS_KEY = '#keywords'
 export const PAGE_SIZE = 20
 export const ADVANCED_QUERY_PREFIX = 'advquery_'

--- a/src/config.js
+++ b/src/config.js
@@ -4,4 +4,3 @@ export const TABLE_PREFIX = 'proj_'
 export const SUBJECT_ID_KEY = 'subject_id'
 export const KEYWORDS_KEY = '#keywords'
 export const PAGE_SIZE = 20
-export const ADVANCED_QUERY_PREFIX = 'advquery_'

--- a/src/config.js
+++ b/src/config.js
@@ -3,3 +3,4 @@ export const DATABASE_NAME = 'projects'
 export const TABLE_PREFIX = 'proj_'
 export const SUBJECT_ID_KEY = 'subject_id'
 export const PAGE_SIZE = 20
+export const ADVANCED_QUERY_PREFIX = 'advquery_'

--- a/src/helpers/convertAdvancedQueryFromString.js
+++ b/src/helpers/convertAdvancedQueryFromString.js
@@ -6,7 +6,7 @@ Converts an advanced query string to an object.
 - Assumption: keys don't contain '='
  */
 
-function convertAdvancedQueryFromString (str = '') {
+export default function convertAdvancedQueryFromString (str = '') {
   const data = {}
   str.match(/{[^{}=]+=[^{}]*}/g)?.forEach(item => {
     const match = item.match(/^{([^=]+)=(.*)}$/)  // Don't use global (g)

--- a/src/helpers/convertAdvancedQueryFromString.js
+++ b/src/helpers/convertAdvancedQueryFromString.js
@@ -1,0 +1,18 @@
+/*
+Converts an advanced query string to an object.
+
+- Example: "{one=abc} {two=} {three====}" should return
+  { one: 'abc', three: '===' }
+- Assumption: keys don't contain '='
+ */
+
+function convertAdvancedQueryFromString (str = '') {
+  const data = {}
+  str.match(/{[^{}=]+=[^{}]*}/g)?.forEach(item => {
+    const match = item.match(/^{([^=]+)=(.*)}$/)  // Don't use global (g)
+    if (match?.[1] && match?.[2]) {  // match[1] is the key, match[2] is the value
+      data[match[1]] = match[2]
+    }
+  })
+  return data
+}

--- a/src/helpers/convertAdvancedQueryToString.js
+++ b/src/helpers/convertAdvancedQueryToString.js
@@ -8,10 +8,9 @@ Converts an advanced query object to a string.
 
 export default function convertAdvancedQueryToString (data) {
   return Object.entries(data).map(([key, val = '']) => {
-    const _key = key.replace(RegExp(`^${ADVANCED_QUERY_PREFIX}`), '')
     const _val = val.trim()  // TODO: what if val has { or } ?
     return (_val)
-      ? `{${_key}=${_val}}`
+      ? `{${key}=${_val}}`
       : ''
   }).join(' ')
 }

--- a/src/helpers/convertAdvancedQueryToString.js
+++ b/src/helpers/convertAdvancedQueryToString.js
@@ -1,0 +1,17 @@
+/*
+Converts an advanced query object to a string.
+
+- Example: { one: 'abc', two: '', three: '===' } should return
+  "{one=abc} {three====}"
+- Assumption: keys don't contain '='
+ */
+
+export default function convertAdvancedQueryToString (data) {
+  return Object.entries(data).map(([key, val = '']) => {
+    const _key = key.replace(RegExp(`^${ADVANCED_QUERY_PREFIX}`), '')
+    const _val = val.trim()  // TODO: what if val has { or } ?
+    return (_val)
+      ? `{${_key}=${_val}}`
+      : ''
+  }).join(' ')
+}

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -51,9 +51,6 @@ export default async function fetchSearchResults (
     queryForDatabase = applyQueryToAllDatabaseFields(project, query)
   }
 
-  console.log('+++ queryForTalk:', queryForTalk)
-  console.log('+++ queryForDatabase:', queryForDatabase)
-
   const allSubjectIds = await Promise.all([
     fetchSearchResults_fromTalk(project.id, queryForTalk),
     fetchSearchResults_fromDatabase(project.id, queryForDatabase)
@@ -74,7 +71,7 @@ function applyQueryToAllDatabaseFields (project, query = '') {
 
   const queryObject = {}
   project.metadata_fields.map(field => (
-    queryObject[field] = [`%${query}%`]
+    queryObject[field] = query
   ))
 
   return queryObject

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -11,6 +11,8 @@ Outputs:
 - Array of unique subject IDs (strings)
  */
 
+import { KEYWORDS_KEY } from '@src/config.js'
+import convertAdvancedQueryFromString from './convertAdvancedQueryFromString.js'
 import fetchSearchResults_fromTalk from './fetchSearchResults_fromTalk.js'
 import fetchSearchResults_fromDatabase from './fetchSearchResults_fromDatabase.js'
 
@@ -22,12 +24,39 @@ export default async function fetchSearchResults (
 
   if (!project) throw new Error('fetchSearchResults() requires a project')
   
-  const queryString = query
-  const queryObject = convertQueryStringToQueryObject(project, query)
+  // const queryString = query
+  // const queryObject = applyQueryToAllDatabaseFields(project, query)
+
+  let queryForTalk = ''
+  let queryForDatabase = {}
+  const queryObject = convertAdvancedQueryFromString(query)
+
+  if (isThisAnAdvancedQuery(query)) {
+    // An advanced query searches for specific values in specific fields,
+    // e.g. "{animal=cat} {color=orange} {loves=lasagna} {hates=mondays}"
+
+    const {
+      [KEYWORDS_KEY]: a,
+      ...b
+    } = queryObject
+
+    queryForTalk = a
+    queryForDatabase = b
+
+  } else {
+    // A simple query searches for a common value across all fields,
+    // e.g. "cat" will return results if either animal/color/loves/hates/etc contains that word.
+    
+    queryForTalk = query
+    queryForDatabase = applyQueryToAllDatabaseFields(project, query)
+  }
+
+  console.log('+++ queryForTalk:', queryForTalk)
+  console.log('+++ queryForDatabase:', queryForDatabase)
 
   const allSubjectIds = await Promise.all([
-    fetchSearchResults_fromTalk(project.id, queryString),
-    fetchSearchResults_fromDatabase(project.id, queryObject)
+    fetchSearchResults_fromTalk(project.id, queryForTalk),
+    fetchSearchResults_fromDatabase(project.id, queryForDatabase)
   ])
 
   // Flatten into a single array, then remove duplicates
@@ -36,7 +65,11 @@ export default async function fetchSearchResults (
   setData(subjectIds)
 }
 
-function convertQueryStringToQueryObject (project, query = '') {
+function isThisAnAdvancedQuery(str) {
+  return str.includes('{') && str.includes('}')
+}
+
+function applyQueryToAllDatabaseFields (project, query = '') {
   if (!project) return {}
 
   const queryObject = {}

--- a/src/helpers/fetchSearchResults_fromDatabase.js
+++ b/src/helpers/fetchSearchResults_fromDatabase.js
@@ -23,6 +23,8 @@ export default async function fetchSearchResults_fromDatabase (
 ) {
   if (!projectId) return []
 
+  if (Object.entries(queryObject).length === 0) return []
+
   // Example: https://subject-set-search-api.zooniverse.org/projects.json?sql=select+*+from+proj_21084+where+%5Bfolder%5D+like+%27%25jamaica%25%27
   try {
     const { where = '', params = [] } = convertQueryObjectToSqlWhere(queryObject)

--- a/src/helpers/fetchSearchResults_fromDatabase.js
+++ b/src/helpers/fetchSearchResults_fromDatabase.js
@@ -5,8 +5,8 @@ Fetches search results from the Subjects database. Specifically, it searches for
 Inputs:
 - (string/int) projectId
 - (object) queryObject: contains keys with values to search for.
-  e.g. { colour: [ 'red', 'blue' ], shape: ['circle'], texture: ['%soft%'] }
-  becomes "SELECT * FROM whatever WHERE (colour = 'red' OR colour = 'blue') AND (shape = 'circle) AND (texture LIKE '%soft%')"
+  e.g. { colour: 'red', shape: 'circle' }
+  becomes "SELECT * FROM whatever WHERE (colour = '%red%') OR (shape = '%circle%')"
 - (function) setData: callback function after successful data fetch
 
 Outputs:
@@ -49,22 +49,18 @@ export default async function fetchSearchResults_fromDatabase (
 function convertQueryObjectToSqlWhere (queryObject = {}) {
   const params = []
   let paramCounter = 0
-  const where = Object.entries(queryObject).map(([field, arr]) => {
-    const fieldPart = arr.map(val => {
-      const existingParam = params.find(p => p[1] === val)
-      let paramKey = ''
-      if (existingParam) {
-        paramKey = existingParam[0]
-      } else {
-        paramKey = `p${paramCounter++}`
-        params.push([paramKey, val])
-      }
-      
-      if (val.includes('%')) return `[${field}] LIKE :${paramKey}`
-      else return `[${field}] = :${paramKey}`
-    }).join(' OR ')
+  const where = Object.entries(queryObject).map(([field, val]) => {
+    const _val = `%${val}%`
+    const existingParam = params.find(p => p[1] === _val)
+    let paramKey = ''
+    if (existingParam) {
+      paramKey = existingParam[0]
+    } else {
+      paramKey = `p${paramCounter++}`
+      params.push([paramKey, _val])
+    }
 
-    return `(${fieldPart})`
+    return `[${field}] LIKE :${paramKey}`
   }).join(' OR ')  // TODO: fix! Is this OR or AND?
 
   return {

--- a/src/helpers/getQuery.js
+++ b/src/helpers/getQuery.js
@@ -5,7 +5,7 @@ Gets ?query parameter from URL. Used to specify user search queries.
 export default function getQuery () {
   try {
     const param = new URLSearchParams(window?.location?.search)
-    return param.get('query') || undefined
+    return param.get('query').trim() || undefined
   } catch (err) {
     return undefined
   }

--- a/src/pages/ProjectPage/ProjectPage.js
+++ b/src/pages/ProjectPage/ProjectPage.js
@@ -36,13 +36,12 @@ function ProjectPage () {
           <Carousel
             wrap={true}
           >
-            {exampleSubjects.map(sbjId => (
-              <Box key={`example-subject-${sbjId}`}>
-                <Text color='drawing-pink'>TODO: description for each subject</Text>
-            
-                <Link to={`/projects/${projectSlug}/subject/${sbjId}`} key={`home-subject-${sbjId}`}>
+            {exampleSubjects.map(sbj => (
+              <Box key={`example-subject-${sbj.id}`}>
+                <Text>{sbj.title}</Text>
+                <Link to={`/projects/${projectSlug}/subject/${sbj.id}`} key={`home-subject-${sbj.id}`}>
                   <SubjectImage
-                    subjectId={sbjId}
+                    subjectId={sbj.id}
                     width={imgWidth}
                     height={imgHeight}
                   />

--- a/src/pages/SearchPage/SearchPage.js
+++ b/src/pages/SearchPage/SearchPage.js
@@ -1,5 +1,6 @@
-import { Box, Text } from 'grommet'
+import { useEffect } from 'react'
 import { observer } from 'mobx-react'
+import { useLocation } from 'react-router-dom'
 
 import AdvancedSearchForm from '@src/components/AdvancedSearchForm'
 import SearchResultsList from '@src/components/SearchResultsList'
@@ -9,9 +10,12 @@ import { useStores } from '@src/store'
 function SearchPage () {
   const query = getQuery() || ''
   const store = useStores()
+  const location = useLocation();
   const project = store.project
 
-  console.log('+++ project', project)
+  useEffect(() => {
+    console.log('Query parameters changed, refreshing Search Page.')
+  }, [ location ])
 
   return (
     <>

--- a/src/pages/SearchPage/SearchPage.js
+++ b/src/pages/SearchPage/SearchPage.js
@@ -1,21 +1,24 @@
 import { Box, Text } from 'grommet'
+import { observer } from 'mobx-react'
 
+import AdvancedSearchForm from '@src/components/AdvancedSearchForm'
 import SearchResultsList from '@src/components/SearchResultsList'
 import getQuery from '@src/helpers/getQuery'
+import { useStores } from '@src/store'
 
-export default function SearchPage () {
+function SearchPage () {
   const query = getQuery() || ''
+  const store = useStores()
+  const project = store.project
+
+  console.log('+++ project', project)
 
   return (
     <>
-      <Box
-        border={true}
-        pad='medium'
-        margin='medium'
-      >
-        <Text color='drawing-pink'>Advanced Search Options/Filters</Text>
-      </Box>
+      <AdvancedSearchForm project={project} />
       <SearchResultsList query={query} />
     </>
   )
 }
+
+export default observer(SearchPage)

--- a/src/projects.json
+++ b/src/projects.json
@@ -10,8 +10,10 @@
       "advanced_search": [
         { "field": "Item", "type": "text" },
         { "field": "Notes", "type": "text" },
+        { "field": "folder", "alias": "Folder", "type": "text" },
+        { "field": "Photographer", "type": "text" },
         { "field": "Sensitive_Image", "alias": "Sensitive Image", "type": "bool" },
-        { "field": "Problematic_Language", "alias": "Problematic Language", "type": "text" }
+        { "field": "Problematic_Language", "alias": "Problematic Language", "type": "bool" }
       ],
       "exampleQuery": "devtest",
       "exampleSubjects": [

--- a/src/projects.json
+++ b/src/projects.json
@@ -8,7 +8,18 @@
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
       ],
       "exampleQuery": "devtest",
-      "exampleSubjects": [ "87892458", "87892456", "87892462" ],
+      "exampleSubjects": [
+        {
+          "id": "87892458",
+          "title": "Example Photo A"
+        }, {
+          "id": "87892456",
+          "title": "Example Photo B"
+        }, {
+          "id": "87892462",
+          "title": "Example Photo C"
+        }
+      ],
       "titleField": "folder"
     }, {
       "name": "Scarlets & Blues (Performance Test Only)",
@@ -18,7 +29,18 @@
         "Date", "Page", "image", "Catalogue"
       ],
       "exampleQuery": "tables",
-      "exampleSubjects": [ "69734802", "69734801", "69734803" ],
+      "exampleSubjects": [
+        {
+          "id": "69734802",
+          "title": "Example Photo A (S&B)"
+        }, {
+          "id": "69734801",
+          "title": "Example Photo B (S&B)"
+        }, {
+          "id": "69734803",
+          "title": "Example Photo C (S&B)"
+        }
+      ],
       "titleField": "Catalogue"
     }
   ]

--- a/src/projects.json
+++ b/src/projects.json
@@ -7,6 +7,12 @@
       "metadata_fields": [
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
       ],
+      "advanced_search": [
+        { "field": "Item", "type": "text" },
+        { "field": "Notes", "type": "text" },
+        { "field": "Sensitive_Image", "alias": "Sensitive Image", "type": "bool" },
+        { "field": "Problematic_Language", "alias": "Problematic Language", "type": "text" }
+      ],
       "exampleQuery": "devtest",
       "exampleSubjects": [
         {
@@ -28,6 +34,7 @@
       "metadata_fields": [
         "Date", "Page", "image", "Catalogue"
       ],
+      "advanced_search": [],
       "exampleQuery": "tables",
       "exampleSubjects": [
         {

--- a/src/strings.json
+++ b/src/strings.json
@@ -21,7 +21,8 @@
     },
     "search_results_list": {
       "no_results": "No items found, sorry",
-      "search_results": "Search results for \"{query}\":"
+      "search_results": "Search results for \"{query}\":",
+      "search_results_all": "No query, so showing a sample of all items:"
     },
     "subject_image": {
       "placeholder": "Placeholder for Subject image",

--- a/src/strings.json
+++ b/src/strings.json
@@ -1,5 +1,8 @@
 {
   "components": {
+    "advanced_search": {
+      "keywords_label": "Keywords (Talk tags)"
+    },
     "footer": "This page made possible by Communities and Crowds, Zooniverse, and viewers like you.",
     "header": {
       "project_button": "Project Home Page",


### PR DESCRIPTION
## PR Overview

This PR adds advanced search functionality to the Community Catalog. Previously, only simple searches were supported,

Explanation: a simple search will search _every_ field of a Subject's metadata + Talk keywords for a matching word, e.g. `"cat"`. An advanced search looks for specific values in specific fields, e.g. `"{animal=cat} {color=orange} {loves=lasagna} {hates=mondays}"`

- ⭐ Advanced Search functionality added:
  - A whole bunch of functions added to parse/unparse advanced search query objects from/to strings.
  - fetchSearchResults() now switches between simple and advanced searches depending on the query string
  - AdvancedSearchForm component added.
  - projects.json updated, allowing the advanced search form for each project to be configured.
- Tweaks:
  - fetchSearchResults_fromDatabase() simplified. The previous version was a bit over-engineered to accommodate way-more-precise-than-necessary search queries.