### PR TITLE
Fix cached pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Zooniverse-powered website for exploring community-tagged images",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --config webpack.prod.js",
+    "build": "export HEAD_COMMIT=${HEAD_COMMIT:-$(git rev-parse --short HEAD)} ; webpack --config webpack.prod.js",
     "start": "webpack serve --config webpack.dev.js",
     "test": "jest"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <meta name="theme-color" content="#00979d">
     <title>Zooniverse Community Catalog</title>
+    <meta name="zooniverse:deployed_commit" content="<%= process.env.HEAD_COMMIT %>">
+    <meta name="zooniverse:build_env" content="<%= process.env.NODE_ENV %>">
+    <meta name="zooniverse:build_date" content="<%= new Date() %>">
     <style>
       * {
         box-sizing: border-box;

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -11,7 +11,7 @@ const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
 module.exports = {
   entry: './src/main.js',
   output: {
-    filename: '[name].js',
+    filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
     publicPath: '/',
   },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -33,6 +33,7 @@ module.exports = {
     ]
   },
   plugins: [
+    new webpack.EnvironmentPlugin(['HEAD_COMMIT']),
     new webpack.ProvidePlugin({
       favicon: 'src/favicon.ico',
       process: 'process/browser',


### PR DESCRIPTION
## PR Overview

Fixes #113 

This PR fixes the issue where https://community-catalog.zooniverse.org/ keeps serving users (up to a week old) cached pages, because the `main.js` file didn't have any hashes in the filename to ensure consistently new files being served.

Build changes:
- Output file, `main.js`, is now `main.{HASH}.js`
- Index.html now contains commit ID, build time, and build environment, to assist with debugging.

These build config settings should have been standard for all our Zooniverse static CFEs, so I'm putting them in now. Thanks to Michelle, Zach, and Jim for pointers on this. 👍 