### PR TITLE
Add "How Did We Get Here?" project

### DIFF
--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -58,7 +58,6 @@ export default function SubjectPage () {
         level='2'
         margin={{ horizontal: 'small', vertical: 'xsmall' }}
         size='1.1em'
-        truncate={true}
       >
         {title}
       </Heading>

--- a/src/projects.json
+++ b/src/projects.json
@@ -7,14 +7,7 @@
       "metadata_fields": [
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
       ],
-      "advanced_search": [
-        { "field": "Item", "type": "text" },
-        { "field": "Notes", "type": "text" },
-        { "field": "folder", "alias": "Folder", "type": "text" },
-        { "field": "Photographer", "type": "text" },
-        { "field": "Sensitive_Image", "alias": "Sensitive Image", "type": "bool" },
-        { "field": "Problematic_Language", "alias": "Problematic Language", "type": "bool" }
-      ],
+      "advanced_search": [],
       "exampleQuery": "devtest",
       "exampleSubjects": [
         {
@@ -55,6 +48,32 @@
       "titleField": "Catalogue",
       "classifyUrl": "https://www.zooniverse.org/projects/bogden/scarlets-and-blues",
       "viewOnTalkUrl": "https://www.zooniverse.org/projects/bogden/scarlets-and-blues/talk/subjects/{subject_id}"
+    }, {
+      "name": "How Did We Get Here?",
+      "slug": "communitiesandcrowds/how-did-we-get-here",
+      "id": 20816,
+      "metadata_fields": [
+        "image1", "image2", "internal_id", "group_id", "part_number", "folder", "#Hazard", "condition", "item", "picture_agency", "photographer", "oversize", "sensitive_image", "sensitive_image_note", "problematic_language", "probelmatic_language_notes", "#Other Number", "notes"
+      ],
+      "advanced_search": [],
+      "exampleQuery": "",
+      "exampleSubjects": [
+        {
+          "id": "90433314",
+          "title": "West Indies | Jamaica - Misc"
+        },
+        {
+          "id": "90433314",
+          "title": "West Indies | Jamaica - Misc"
+        },
+        {
+          "id": "90433314",
+          "title": "West Indies | Jamaica - Misc"
+        }
+      ],
+      "titleField": "folder",
+      "classifyUrl": "https://frontend.preview.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/classify/workflow/23790/subject/{subject_id}",
+      "viewOnTalkUrl": "https://www.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/talk/subjects/{subject_id}"
     }
   ]
 }

--- a/src/projects.json
+++ b/src/projects.json
@@ -63,12 +63,12 @@
           "title": "West Indies | Jamaica - Misc"
         },
         {
-          "id": "90433314",
-          "title": "West Indies | Jamaica - Misc"
+          "id": "90433278",
+          "title": "\"Coloured People\" in Britain | Riots and Demonstrations (Including Notting Hill 1958) | Folder 1"
         },
         {
-          "id": "90433314",
-          "title": "West Indies | Jamaica - Misc"
+          "id": "88952217",
+          "title": "Medical|Nurses - Foreign, \"Coloured\", etc."
         }
       ],
       "titleField": "folder",


### PR DESCRIPTION
## PR Overview

This PR adds the ["How Did We Get Here?"](https://frontend.preview.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here) Zooniverse project to the Community Catalog. HDWGH is (one of?) the main project(s?) under the larger Communities & Crowds project, so we're finally reaching the "ready to go live" stage

- Project URL will be: https://community-catalog.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here
- Note that HDWGH's metadata fields differs slightly from the "Community Catalog (Stable Test Project)" test project, and includes some typos. Ah well! We'll see what happens if/when newer subjects correct/change those fields.

Associated external updates:
- HDWGH was also added to the Subject Set Search API.
- See https://github.com/zooniverse/subject-set-search-api/pull/52, https://github.com/zooniverse/subject-set-search-api/pull/53