### PR TITLE
Header search now shows/retains queries

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -18,6 +18,7 @@ import { observer } from 'mobx-react'
 import strings from '@src/strings.json'
 import { useStores } from '@src/store'
 import getEnv from '@src/helpers/getEnv.js'
+import getQuery from '@src/helpers/getQuery.js'
 
 const LogoLink = styled(Link)`
   color: #e2e5e9;
@@ -75,6 +76,8 @@ function Header () {
   const env = getEnv()
   const size = useContext(ResponsiveContext)
   const isNarrowView = size === 'small'
+  const defaultQuery = getQuery() || ''
+  const [ query, setQuery ] = useState(defaultQuery)
 
   if (!project) return (
     <Box
@@ -92,10 +95,17 @@ function Header () {
     >
       <HeaderLogoAndTitle />
       {(!isNarrowView)
-        ? <WideProjectControls project={project} env={env} />
+        ? <WideProjectControls
+            project={project}
+            env={env}
+            query={query}
+            setQuery={setQuery}
+          />
         : <NarrowProjectControls
             project={project}
             env={env}
+            query={query}
+            setQuery={setQuery}
           />
       }
       {(!isNarrowView)
@@ -134,7 +144,9 @@ function HeaderLogoAndTitle () {
 
 function WideProjectControls ({
   project,
-  env
+  env,
+  query = '',
+  setQuery = () => {},
 }) {
   const projectSlug = project?.slug || ''
   const projectURL = `https://www.zooniverse.org/projects/${projectSlug}`
@@ -164,6 +176,8 @@ function WideProjectControls ({
         <HeaderSearchInput
           name='query'
           icon={<Search color='black' size='small' />}
+          value={query}
+          onChange={e => setQuery(e?.target?.value)}
           width={{ min: 'medium', max: 'xlarge' }}
         />
         {(env)
@@ -177,7 +191,9 @@ function WideProjectControls ({
 
 function NarrowProjectControls ({
   project,
-  env
+  env,
+  query = '',
+  setQuery = () => {},
 }) {
   const projectSlug = project?.slug || ''
   const projectURL = `https://www.zooniverse.org/projects/${projectSlug}`
@@ -222,6 +238,8 @@ function NarrowProjectControls ({
             <HeaderSearchInput
               name='query'
               icon={<Search size='small' />}
+              value={query}
+              onChange={e => setQuery(e?.target?.value)}
             />
             {(env)
               ? <input name='env' value={env} type='hidden' />

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,4 +1,6 @@
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+
 import {
   Accordion,
   AccordionPanel,
@@ -76,8 +78,13 @@ function Header () {
   const env = getEnv()
   const size = useContext(ResponsiveContext)
   const isNarrowView = size === 'small'
-  const defaultQuery = getQuery() || ''
-  const [ query, setQuery ] = useState(defaultQuery)
+  const queryFromUrl = getQuery() || ''
+  const [ query, setQuery ] = useState(queryFromUrl)
+  const location = useLocation()
+
+  useEffect(function onUrlChange () {
+    setQuery(queryFromUrl)
+  }, [ location ])
 
   if (!project) return (
     <Box

--- a/src/components/Tester/Tester.js
+++ b/src/components/Tester/Tester.js
@@ -47,8 +47,6 @@ export default function Tester () {
         name: query
       })
 
-      console.log('+++ response.body: ', response.body)
-
       if (!response?.ok) throw new Error('Couldn\'t fetch tag search results')
 
       const results = response.body?.popular.filter(s => s?.body) || []

--- a/src/pages/SearchPage/SearchPage.js
+++ b/src/pages/SearchPage/SearchPage.js
@@ -2,17 +2,14 @@ import { useEffect } from 'react'
 import { observer } from 'mobx-react'
 import { useLocation } from 'react-router-dom'
 
-import AdvancedSearchForm from '@src/components/AdvancedSearchForm'
 import SearchResultsList from '@src/components/SearchResultsList'
 import getQuery from '@src/helpers/getQuery'
-import { useStores } from '@src/store'
 
 function SearchPage () {
   const query = getQuery() || ''
-  const { project } = useStores()
-  const location = useLocation();
+  const location = useLocation()
   
-  useEffect(() => {
+  useEffect(function onUrlChange () {
     console.log('Query parameters changed, refreshing Search Page.')
   }, [ location ])
 


### PR DESCRIPTION
## PR Overview

This PR is a small tweak to the UX: the header search field now shows/retains the search queries from users, i.e. it displays the value of the `?query=...`

Previously, every time a user executes a search, the search field would reset to blank.