### PR TITLE
Search Results paging ("Show More")

### DIFF
--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -15,11 +15,28 @@ function SearchResultsList ({
   const { project, showingSensitiveContent, setShowingSensitiveContent } = useStores()
   const titleField = project?.titleField || ''
   const [ searchResults, setSearchResults ] = useState([])
+  const [ status, setStatus ] = useState('ready')  // ready|fetching|error
 
-  useEffect(function () {
-    if (project) {
-      fetchSearchResults(project, query, setSearchResults)
+  useEffect(function onQueryChange () {
+    setStatus('ready')
+    setSearchResults([])
+  }, [ query ])
+
+  useEffect(function onProjectOrQueryChange () {
+    async function doFetchData () {
+      if (project) {
+        try {
+          setStatus('fetching')
+          await fetchSearchResults(project, query, setSearchResults)
+          setStatus('ready')
+
+        } catch (err) {
+          setStatus('error')
+          console.error(err)
+        }
+      }
     }
+    doFetchData()
   }, [ project, query ])
 
   return (

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -3,10 +3,13 @@ import { Box, CheckBox, ResponsiveContext, Spinner, Text } from 'grommet'
 import { observer } from 'mobx-react'
 
 import strings from '@src/strings.json'
+import { ASYNC_STATES } from '@src/config.js'
 import { useStores } from '@src/store'
 import fetchSearchResults from '@src/helpers/fetchSearchResults.js'
 
 import SearchResult from './SearchResult.js'
+
+const { READY, FETCHING, ERROR } = ASYNC_STATES
 
 function SearchResultsList ({
   query = '',
@@ -15,10 +18,10 @@ function SearchResultsList ({
   const { project, showingSensitiveContent, setShowingSensitiveContent } = useStores()
   const titleField = project?.titleField || ''
   const [ searchResults, setSearchResults ] = useState([])
-  const [ status, setStatus ] = useState('ready')  // ready|fetching|error
+  const [ status, setStatus ] = useState(READY)  // ready|fetching|error
 
   useEffect(function onQueryChange () {
-    setStatus('ready')
+    setStatus(READY)
     setSearchResults([])
   }, [ query ])
 
@@ -26,9 +29,9 @@ function SearchResultsList ({
     async function doFetchData () {
       if (project) {
         try {
-          setStatus('fetching')
+          setStatus(FETCHING)
           await fetchSearchResults(project, query, setSearchResults)
-          setStatus('ready')
+          setStatus(READY)
 
         } catch (err) {
           setStatus('error')
@@ -77,9 +80,9 @@ function SearchResultsList ({
           />
         ))}
       </Box>
-      {(status === 'ready' && searchResults.length === 0) && (<Text textAlign='center'>{strings.components.search_results_list.no_results}</Text>)}
-      {(status === 'fetching') && (<Box direction='row' justify='center'><Spinner /></Box>)}
-      {(status === 'error') && (<Text color='red' textAlign='center'>{strings.general.error}</Text>)}
+      {(status === READY && searchResults.length === 0) && (<Text textAlign='center'>{strings.components.search_results_list.no_results}</Text>)}
+      {(status === FETCHING) && (<Box direction='row' justify='center'><Spinner /></Box>)}
+      {(status === ERROR) && (<Text color='red' textAlign='center'>{strings.general.error}</Text>)}
     </Box>
   )
 }

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -17,7 +17,9 @@ function SearchResultsList ({
   const [ searchResults, setSearchResults ] = useState([])
 
   useEffect(function () {
-    if (project) fetchSearchResults(project, query, setSearchResults)
+    if (project) {
+      fetchSearchResults(project, query, setSearchResults)
+    }
   }, [ project, query ])
 
   return (

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
-import { Box, CheckBox, ResponsiveContext, Text } from 'grommet'
+import { Box, CheckBox, ResponsiveContext, Spinner, Text } from 'grommet'
 import { observer } from 'mobx-react'
 
 import strings from '@src/strings.json'
@@ -77,7 +77,9 @@ function SearchResultsList ({
           />
         ))}
       </Box>
-      {(searchResults.length === 0) && <Text>{strings.components.search_results_list.no_results}</Text>}
+      {(status === 'ready' && searchResults.length === 0) && (<Text textAlign='center'>{strings.components.search_results_list.no_results}</Text>)}
+      {(status === 'fetching') && (<Box direction='row' justify='center'><Spinner /></Box>)}
+      {(status === 'error') && (<Text color='red' textAlign='center'>{strings.general.error}</Text>)}
     </Box>
   )
 }

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -57,9 +57,10 @@ function SearchResultsList ({
     const newResults = [ ...searchResults, ...subjectIds ]
     const noDuplicates = Array.from(new Set(newResults))
     setSearchResults(noDuplicates)
+    if (subjectIds.length === 0) setMoreToShow(false)
   }
 
-  const showMoreButton = query.trim().length > 0
+  const showMoreButton = (status === READY) && query.trim().length > 0  // Don't show "Show More" for the randomised Subjects
 
   function fetchMore () {
     if (status !== READY) return
@@ -107,19 +108,19 @@ function SearchResultsList ({
       {(status === READY && searchResults.length === 0) && (<Text textAlign='center'>{strings.components.search_results_list.no_results}</Text>)}
       {(status === FETCHING) && (<Box direction='row' justify='center'><Spinner /></Box>)}
       {(status === ERROR) && (<Text color='red' textAlign='center'>{strings.general.error}</Text>)}
-      {(showMoreButton) && moreToShow ? (
+      {(showMoreButton) && (moreToShow ? (
         <Box direction='row' justify='center'>
           <CleanLink onClick={fetchMore}>
-            <Text color='black'>{strings.components.keywords_list.show_more}</Text>
+            <Text color='black'>{strings.components.search_results_list.show_more}</Text>
           </CleanLink>
           </Box>
       ) : (
         <Box direction='row' justify='center'>
           <CleanLink>
-            <Text color='black'>{strings.components.keywords_list.no_more}</Text>
+            <Text color='black'>{strings.components.search_results_list.no_more}</Text>
           </CleanLink>
         </Box>
-      )}
+      ))}
     </Box>
   )
 }

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,6 @@ export const DATABASE_NAME = 'projects'
 export const TABLE_PREFIX = 'proj_'
 export const SUBJECT_ID_KEY = 'subject_id'
 export const KEYWORDS_KEY = '#keywords'
-export const PAGE_SIZE = 20  // When fetching resources from Panoptes, request this many items per page.
+export const PAGE_SIZE = 10  // When fetching resources from Panoptes or the database, request this many items per page.
 export const LAYOUT_MAIN_MAX_WIDTH = 1280  // App's <main> element will not exceed this width.
 export const NARROW_VIEW_WIDTH = 800  // At this width of below, we'll use a narrow (responsive mobile) view.

--- a/src/config.js
+++ b/src/config.js
@@ -6,3 +6,8 @@ export const KEYWORDS_KEY = '#keywords'
 export const PAGE_SIZE = 10  // When fetching resources from Panoptes or the database, request this many items per page.
 export const LAYOUT_MAIN_MAX_WIDTH = 1280  // App's <main> element will not exceed this width.
 export const NARROW_VIEW_WIDTH = 800  // At this width of below, we'll use a narrow (responsive mobile) view.
+export const ASYNC_STATES = {
+  READY: 'ready',
+  FETCHING: 'fetching',
+  ERROR: 'error'
+}

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -39,21 +39,8 @@ export default async function fetchSearchResults (
     setData(subjectIds)
     return
 
-  } else if (isThisAnAdvancedQuery(query)) {
-    // An advanced query searches for specific values in specific fields,
-    // e.g. "{animal=cat} {color=orange} {loves=lasagna} {hates=mondays}"
-
-    const {
-      [KEYWORDS_KEY]: a,
-      ...b
-    } = queryObject
-
-    queryForTalk = a
-    queryForDatabase = b
-
   } else {
-    // A simple query searches for a common value across all fields,
-    // e.g. "cat" will return results if either animal/color/loves/hates/etc contains that word.
+    // A simple query searches for a common value across all fields.
     
     queryForTalk = query
     queryForDatabase = applyQueryToAllDatabaseFields(project, query)
@@ -68,10 +55,6 @@ export default async function fetchSearchResults (
   const subjectIds = Array.from(new Set(allSubjectIds.flat()))
 
   setData(subjectIds)
-}
-
-function isThisAnAdvancedQuery(str) {
-  return str.includes('{') && str.includes('}')
 }
 
 function applyQueryToAllDatabaseFields (project, query = '') {

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -18,7 +18,7 @@ import fetchRandomSubjects from './fetchRandomSubjects.js'
 export default async function fetchSearchResults (
   project,
   query = '',
-  setData = (data) => { console.log('fetchSearchResults_fromTalk: ', data) }
+  page = 1,
 ) {
 
   if (!project) throw new Error('fetchSearchResults() requires a project')
@@ -27,8 +27,7 @@ export default async function fetchSearchResults (
     // The default query simply results in a random 
 
     const subjectIds = await fetchRandomSubjects(project.id)
-    setData(subjectIds)
-    return
+    return subjectIds
 
   } else {
     // A simple query searches for a common value across all fields.
@@ -41,11 +40,10 @@ export default async function fetchSearchResults (
       fetchSearchResults_fromDatabase(project.id, queryForDatabase)
     ])
   
-    // Flatten into a single array, then remove duplicates
-    const subjectIds = Array.from(new Set(allSubjectIds.flat()))
+    // // Flatten into a single array, then remove duplicates
+    // const subjectIds = Array.from(new Set(allSubjectIds.flat()))
 
-    setData(subjectIds)
-    return
+    return allSubjectIds.flat()
   }
 }
 

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -36,8 +36,8 @@ export default async function fetchSearchResults (
     const queryForDatabase = applyQueryToRelevantDatabaseFields(project, query)
 
     const allSubjectIds = await Promise.all([
-      fetchSearchResults_fromTalk(project.id, queryForTalk),
-      fetchSearchResults_fromDatabase(project.id, queryForDatabase)
+      fetchSearchResults_fromTalk(project.id, queryForTalk, page),
+      fetchSearchResults_fromDatabase(project.id, queryForDatabase, page)
     ])
   
     // // Flatten into a single array, then remove duplicates

--- a/src/helpers/fetchSearchResults_fromDatabase.js
+++ b/src/helpers/fetchSearchResults_fromDatabase.js
@@ -27,7 +27,7 @@ export default async function fetchSearchResults_fromDatabase (
   // Example: https://subject-set-search-api.zooniverse.org/projects.json?sql=select+*+from+proj_21084+where+%5Bfolder%5D+like+%27%25jamaica%25%27
   try {
     const { where = '', params = [] } = convertQueryObjectToSqlWhere(queryObject)
-    const sqlQuery = encodeURIComponent(`SELECT subject_id FROM ${TABLE_PREFIX}${projectId} ${where ? `WHERE ${where}` : ''} LIMIT ${PAGE_SIZE}`)
+    const sqlQuery = encodeURIComponent(`SELECT subject_id FROM ${TABLE_PREFIX}${projectId} ${where ? `WHERE ${where}` : ''} LIMIT ${PAGE_SIZE} OFFSET ${(page - 1) * PAGE_SIZE}`)
     const sqlParam = params.map(p => `&${p[0]}=${encodeURIComponent(p[1])}`, '').join('')
 
     const url = `${DATABASE_URL}/${DATABASE_NAME}.json?sql=${sqlQuery}${sqlParam}`

--- a/src/helpers/fetchSearchResults_fromDatabase.js
+++ b/src/helpers/fetchSearchResults_fromDatabase.js
@@ -17,7 +17,8 @@ import {
 
 export default async function fetchSearchResults_fromDatabase (
   projectId,
-  queryObject = {}
+  queryObject = {},
+  page = 1,
 ) {
   if (!projectId) return []
 

--- a/src/helpers/fetchSearchResults_fromTalk.js
+++ b/src/helpers/fetchSearchResults_fromTalk.js
@@ -12,6 +12,7 @@ Outputs:
  */
 
 import { talkAPI } from '@zooniverse/panoptes-js'
+import { PAGE_SIZE } from '@src/config.js'
 
 export default async function fetchSearchResults_fromTalk (
   projectId,
@@ -25,7 +26,7 @@ export default async function fetchSearchResults_fromTalk (
       section: `project-${projectId}`,
       taggable_type: 'Subject',
       page: 1,
-      page_size: 20,
+      page_size: PAGE_SIZE,
       name: queryString
     })
 

--- a/src/helpers/fetchSearchResults_fromTalk.js
+++ b/src/helpers/fetchSearchResults_fromTalk.js
@@ -16,7 +16,8 @@ import { PAGE_SIZE } from '@src/config.js'
 
 export default async function fetchSearchResults_fromTalk (
   projectId,
-  queryString = ''
+  queryString = '',
+  page = 1
 ) {
   if (!projectId) return []
 
@@ -25,7 +26,7 @@ export default async function fetchSearchResults_fromTalk (
     const response = await talkAPI.get('/tags/popular', {
       section: `project-${projectId}`,
       taggable_type: 'Subject',
-      page: 1,
+      page,
       page_size: PAGE_SIZE,
       name: queryString
     })

--- a/src/strings.json
+++ b/src/strings.json
@@ -61,7 +61,8 @@
   },
   "general": {
     "app_name": "Communities & Crowds",
-    "data_placeholder": "Data placeholder"
+    "data_placeholder": "Data placeholder",
+    "error": "ERROR: please see dev console for details"
   },
   "messages": {
     "app_ready": "App ready.",

--- a/src/strings.json
+++ b/src/strings.json
@@ -24,7 +24,9 @@
       "no_results": "No items found, sorry",
       "search_results": "Search results for \"{query}\":",
       "search_results_random": "Continue exploring:",
-      "show_sensitive_images": "Show sensitive images"
+      "show_sensitive_images": "Show sensitive images",
+      "no_more": "No more to show",
+      "show_more": "Show More"
     },
     "subject_actions": {
       "add_to_collection": "Add to Collection",


### PR DESCRIPTION
## PR Overview

This PR adds the ability for the Search Results List component to show more results.

Logic updates:
- Page size now reduced from 20 to 10, for both Panoptes fetches (Talk) and Subject Set Search API (database) fetches.
- fetchSearchResults(), fetchSearchResults_fromTalk(), fetchSearchResults_fromDatabase(), have all been massively rejiggered. For example, fetchSearchResults now just returns subject IDs instead of requiring the 'setData' function.
- SearchResultsList is now responsible for handling duplicate Subjects. Previously, fetchSearchResults did this.

UI updates:
- SearchResultsList:
  - Now shows ready/fetching/error states. (Hurrah! This is a major UI improvement.)
  - Now has a "Show More" button. Clicking on it fetches new items, until there's nothing more to be fetched.
    - NOTE: "Show More" doesn't show when there's no query, i.e. when the list is showing randomised "Continue Exploring" results.
    - NOTE: clicking on "Show More" doesn't always pull a consistent number of items per fetch, since 1. we're combining Talk results and database results (so we might get 10+10 results, or 0+10 results, or anything in between), and 2. we're removing duplicates (so out of 10 results, we might only get 8 unique ones). This complication is why we don't have standard paging, btw.
