### PR TITLE
Search Results List: left-align, plus narrow view

### DIFF
--- a/src/components/SearchResultsList/SearchResult.js
+++ b/src/components/SearchResultsList/SearchResult.js
@@ -3,6 +3,7 @@ import { Box, Text } from 'grommet'
 import { Hide as SensitiveContentIcon } from 'grommet-icons'
 import styled from 'styled-components'
 
+import { SUBJECT_IMAGE_SIZE } from '@src/config.js'
 import strings from '@src/strings.json'
 import Link from '@src/components/Link'
 import SubjectImage from '@src/components/SubjectImage'
@@ -15,10 +16,10 @@ const CleanLink = styled(Link)`
 
 const SensitiveContentBox = styled(Box)`
   position: relative;
-  top: -200px;
-  width: 200px;
-  height: 200px;
-  margin-bottom: -200px;
+  top: -${SUBJECT_IMAGE_SIZE}px;
+  width: ${SUBJECT_IMAGE_SIZE}px;
+  height: ${SUBJECT_IMAGE_SIZE}px;
+  margin-bottom: -${SUBJECT_IMAGE_SIZE}px;
   background: rgba(128, 128, 128, 0.5);
 `
 
@@ -45,14 +46,14 @@ export default function SearchResult ({
       <Box
         background='white'
         elevation='small'
-        width='200px'
-        margin={{ bottom: 'small' }}
+        width={`${SUBJECT_IMAGE_SIZE}px`}
+        margin={{ bottom: 'small', right: 'small' }}
       >
         <SubjectImage
           subject={subjectData}
           small={true}
-          width={200}
-          height={200}
+          width={SUBJECT_IMAGE_SIZE}
+          height={SUBJECT_IMAGE_SIZE}
           blur={hideContent}
         />
         {(hideContent)

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -91,7 +91,7 @@ function SearchResultsList ({
       </Box>
       <Box
         direction='row'
-        justify='start'
+        justify={(size !== 'small') ? 'start' : 'center'}
         wrap={true}
       >
         {searchResults.map(subjectId => (

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -91,7 +91,6 @@ function SearchResultsList ({
       </Box>
       <Box
         direction='row'
-        gap='medium'
         justify='start'
         wrap={true}
       >

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -92,7 +92,7 @@ function SearchResultsList ({
       <Box
         direction='row'
         gap='medium'
-        justify='center'
+        justify='start'
         wrap={true}
       >
         {searchResults.map(subjectId => (
@@ -109,15 +109,15 @@ function SearchResultsList ({
       {(status === FETCHING) && (<Box direction='row' justify='center'><Spinner /></Box>)}
       {(status === ERROR) && (<Text color='red' textAlign='center'>{strings.general.error}</Text>)}
       {(showMoreButton) && (moreToShow ? (
-        <Box direction='row' justify='center'>
+        <Box direction='row' justify='end'>
           <CleanLink onClick={fetchMore}>
-            <Text color='black'>{strings.components.search_results_list.show_more}</Text>
+            <Text color='black' weight='normal'>{strings.components.search_results_list.show_more}</Text>
           </CleanLink>
           </Box>
       ) : (
-        <Box direction='row' justify='center'>
+        <Box direction='row' justify='end'>
           <CleanLink>
-            <Text color='black'>{strings.components.search_results_list.no_more}</Text>
+            <Text color='black' weight='normal'>{strings.components.search_results_list.no_more}</Text>
           </CleanLink>
         </Box>
       ))}

--- a/src/components/SubjectImage/SubjectImage.js
+++ b/src/components/SubjectImage/SubjectImage.js
@@ -3,6 +3,7 @@ import { Box, Image } from 'grommet'
 import { Image as ImageIcon } from 'grommet-icons'
 import styled from 'styled-components'
 
+import { SUBJECT_IMAGE_SIZE } from '@src/config.js'
 import strings from '@src/strings.json'
 import fetchSubject from '@src/helpers/fetchSubject'
 
@@ -19,8 +20,8 @@ export default function SubjectImage ({
   src,
   subject = undefined,
   subjectId = '',  // For an example, use Subject '69734802', of Project 12268, in Subject Set 98889. see https://www.zooniverse.org/projects/bogden/scarlets-and-blues/talk/subjects/69734802
-  width = 200,
-  height = 200,
+  width = SUBJECT_IMAGE_SIZE,
+  height = SUBJECT_IMAGE_SIZE,
   fit,
   small = false,
   blur = false,  // Blur the image. Used to "hide" sensitive content.

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ export const DATABASE_NAME = 'projects'
 export const TABLE_PREFIX = 'proj_'
 export const SUBJECT_ID_KEY = 'subject_id'
 export const KEYWORDS_KEY = '#keywords'
+export const SUBJECT_IMAGE_SIZE = 186
 export const PAGE_SIZE = 10  // When fetching resources from Panoptes or the database, request this many items per page.
 export const LAYOUT_MAIN_MAX_WIDTH = 1280  // App's <main> element will not exceed this width.
 export const NARROW_VIEW_WIDTH = 800  // At this width of below, we'll use a narrow (responsive mobile) view.

--- a/src/strings.json
+++ b/src/strings.json
@@ -11,7 +11,7 @@
     },
     "keywords_list": {
       "no_more": "No more to show",
-      "show_more": "Show More",
+      "show_more": "Show more",
       "start_exploring": "Use these keywords to start exploring:"
     },
     "random_button": {
@@ -25,8 +25,8 @@
       "search_results": "Search results for \"{query}\":",
       "search_results_random": "Continue exploring:",
       "show_sensitive_images": "Show sensitive images",
-      "no_more": "No more to show",
-      "show_more": "Show More"
+      "no_more": "No more to see",
+      "show_more": "See more"
     },
     "subject_actions": {
       "add_to_collection": "Add to Collection",


### PR DESCRIPTION
## PR Overview

Follows #125 

This PR changes the layout for the Search Results List to more closely match the current design.

- By default, search results are now left-aligned instead of center-aligned.
- On narrow views, search results are center-aligned.
- The size of "Search Result" items has been tweaked so there's less "dead space" on the right at optimal viewport widths.