### PR TITLE
Fix useEffects and add fetch UI

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -39,7 +39,7 @@ export default function App () {
       store.setUser(user)
       setInitialised(true)
     } catch (err) {
-      console.error(err)
+      console.error('<App>', err)
     }
   }
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -82,7 +82,7 @@ function Header () {
   const [ query, setQuery ] = useState(queryFromUrl)
   const location = useLocation()
 
-  useEffect(function onUrlChange () {
+  useEffect(function onUrlChange_getQueryFromUrl () {
     setQuery(queryFromUrl)
   }, [ location ])
 

--- a/src/components/KeywordsList/KeywordsList.js
+++ b/src/components/KeywordsList/KeywordsList.js
@@ -53,7 +53,7 @@ function KeywordsList () {
 
       } catch (err) {
         setStatus(ERROR)
-        console.error(err)
+        console.error('<KeywordsList>', err)
       }
     }
   }

--- a/src/components/KeywordsList/KeywordsList.js
+++ b/src/components/KeywordsList/KeywordsList.js
@@ -30,6 +30,15 @@ function KeywordsList () {
   const [ page, setPage ] = useState(1)
   const [ moreToShow, setMoreToShow ] = useState(true)  // If there's more to show, then we should show "Show More", you dig?
 
+  /*
+  useEffect(function onProjectChange () {
+    // Reset
+    setKeywordsData([])
+    setPage(1)
+    setMoreToShow(true)
+  }, [ project ])
+  */
+
   function getMoreKeywords () {
     setPage(page + 1)
   }
@@ -39,7 +48,7 @@ function KeywordsList () {
     if (data.length === 0) setMoreToShow(false)
   }
 
-  useEffect(function () {
+  useEffect(function onTargetChange_fetchData () {
     if (page <= 1) {  // Reset if necessary
       setKeywordsData([])
       setMoreToShow(true)

--- a/src/components/ProjectContainer/ProjectContainer.js
+++ b/src/components/ProjectContainer/ProjectContainer.js
@@ -1,16 +1,9 @@
 import { useEffect } from 'react'
-import { Heading, Text } from 'grommet'
 import { Outlet, useParams } from 'react-router-dom'
-import styled from 'styled-components'
 
 import strings from '@src/strings.json'
 import { useStores } from '@src/store'
 import projectsJson from '@src/projects.json'
-import Link from '@src/components/Link'
-
-const ProjectLink = styled(Link)`
-  text-decoration: none;
-`
 
 export default function ProjectContainer ({}) {
   const store = useStores()
@@ -21,7 +14,7 @@ export default function ProjectContainer ({}) {
   const projectSlug = `${projectOwner}/${projectName}`.toLowerCase()
   const selectedProject = projectsJson.projects.find(p => p.slug === projectSlug)
 
-  useEffect(function () {
+  useEffect(function onTargetChange_setData () {
     store.setProject(selectedProject)
   }, [ selectedProject ])
 

--- a/src/components/RandomButton/RandomButton.js
+++ b/src/components/RandomButton/RandomButton.js
@@ -41,7 +41,7 @@ export default function RandomButton ({
         throw new Error ('No Subjects available, apparently. Check database table isn\'t empty.')
       }
     } catch (err) {
-      console.error(err)
+      console.error('<RandomButton>', err)
       setIsWorking(false)
       setMessage(strings.components.random_button.error)
     }

--- a/src/components/SearchResultsList/SearchResult.js
+++ b/src/components/SearchResultsList/SearchResult.js
@@ -50,7 +50,7 @@ export default function SearchResult ({
       setStatus(READY)
     } catch (err) {
       setStatus(ERROR)
-      console.error(err)
+      console.error('<SearchResult>', err)
     }
   }
   

--- a/src/components/SearchResultsList/SearchResult.js
+++ b/src/components/SearchResultsList/SearchResult.js
@@ -32,7 +32,7 @@ export default function SearchResult ({
   const [ subjectData, setSubjectData ] = useState(null)
   const title = subjectData?.metadata?.[titleField] || ''
 
-  useEffect(function () {
+  useEffect(function onTargetChange_fetchData () {
     if (subjectId) fetchSubject(subjectId, setSubjectData)
   }, [ subjectId ])
   

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -49,7 +49,7 @@ function SearchResultsList ({
 
       } catch (err) {
         setStatus(ERROR)
-        console.error(err)
+        console.error('<SearchResultsList>', err)
       }
     }
   }

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -26,14 +26,14 @@ function SearchResultsList ({
   const [ page, setPage ] = useState(1)
   const [ moreToShow, setMoreToShow ] = useState(true)  // If there's more to show, then we should show "Show More", you dig?
 
-  useEffect(function onQueryChange () {
+  useEffect(function onQueryChange_resetData () {
     setSearchResults([])
     setStatus(READY)
     setPage(1)
     setMoreToShow(true)
   }, [ query ])
 
-  useEffect(function onProjectOrQueryChange () {
+  useEffect(function onTargetChange_fetchData () {
     doFetchData(1)
   }, [ project, query ])
 

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -11,6 +11,7 @@ import fetchSearchResults from '@src/helpers/fetchSearchResults.js'
 import SearchResult from './SearchResult.js'
 
 const { READY, FETCHING, ERROR } = ASYNC_STATES
+
 const CleanLink = styled(Anchor)`
   text-decoration: none;
 `
@@ -22,7 +23,7 @@ function SearchResultsList ({
   const { project, showingSensitiveContent, setShowingSensitiveContent } = useStores()
   const titleField = project?.titleField || ''
   const [ searchResults, setSearchResults ] = useState([])
-  const [ status, setStatus ] = useState(READY)  // ready|fetching|error
+  const [ status, setStatus ] = useState(READY)
   const [ page, setPage ] = useState(1)
   const [ moreToShow, setMoreToShow ] = useState(true)  // If there's more to show, then we should show "Show More", you dig?
 
@@ -47,7 +48,7 @@ function SearchResultsList ({
         setStatus(READY)
 
       } catch (err) {
-        setStatus('error')
+        setStatus(ERROR)
         console.error(err)
       }
     }

--- a/src/components/SubjectImage/SubjectImage.js
+++ b/src/components/SubjectImage/SubjectImage.js
@@ -51,7 +51,7 @@ export default function SubjectImage ({
       setStatus(READY)
     } catch (err) {
       setStatus(ERROR)
-      console.error(err)
+      console.error('<SubjectImage>', err)
     }
   }
   

--- a/src/components/SubjectImage/SubjectImage.js
+++ b/src/components/SubjectImage/SubjectImage.js
@@ -29,7 +29,7 @@ export default function SubjectImage ({
   const [ subjectData, setSubjectData ] = useState(subject)
   const index = 0
 
-  useEffect(function () {
+  useEffect(function onTargetChange_fetchData () {
     if (subject) setSubjectData(subject)
 
     // If no Subject has been specified, but we have a Subject ID, fetch that Subject.

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Box, Text } from 'grommet'
+import { Box, Spinner, Text } from 'grommet'
 import { Code as CodeIcon } from 'grommet-icons'
 import styled from 'styled-components'
 import { observer } from 'mobx-react'
 
 import strings from '@src/strings.json'
+import { ASYNC_STATES } from '@src/config.js'
 import { useStores } from '@src/store'
 import fetchKeywords from '@src/helpers/fetchKeywords'
 import Link from '@src/components/Link'
@@ -23,6 +24,8 @@ const KeywordBox = styled(Box)`
   }
 `
 
+const { READY, FETCHING, ERROR } = ASYNC_STATES
+
 function SubjectKeywords ({
   subject = undefined,
 }) {
@@ -31,17 +34,29 @@ function SubjectKeywords ({
   const projectSlug = project?.slug || '' 
 
   const [ keywordsData, setKeywordsData ] = useState([])
+  const [ status, setStatus ] = useState(READY)
 
-  useEffect(function onTargetChange_fetchData () {
-    if (subject) {
-      fetchKeywords(
-        projectId,
-        1,  // Page
-        subject
-      )
-    }
-    // TODO: fetch more than one page of keywords?
+  useEffect(function onTargetChange_resetThenFetchData () {
+    setKeywordsData([])
+    setStatus(READY)
+    doFetchData()
   }, [ projectId, subject ])
+
+  async function doFetchData() {
+    if (subject) {
+      try {
+        setStatus(FETCHING)
+        const keywords = await fetchKeywords(projectId, 1, subject)
+        setKeywordsData(keywords)
+        // TODO: fetch more than one page of keywords?
+        setStatus(READY)
+
+      } catch (err) {
+        setStatus(ERROR)
+        console.error(err)
+      }
+    }
+  }
 
   if (!subject) return (
     <CodeIcon a11yTitle={strings.general.data_placeholder} />
@@ -61,7 +76,7 @@ function SubjectKeywords ({
         justify='end'
         wrap={true}
       >
-        {(keywordsData.length === 0)
+        {(status === READY && keywordsData.length === 0)
           ? <Text>{strings.components.subject_keywords.no_keywords}</Text>
           : null
         }
@@ -81,6 +96,8 @@ function SubjectKeywords ({
             </KeywordBox>
           </KeywordLink>
         ))}
+        {(status === FETCHING) && (<Spinner />)}
+        {(status === ERROR) && (<Text color='red'>{strings.general.error}</Text>)}
       </Box>
     </Box>
   )

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -32,7 +32,7 @@ function SubjectKeywords ({
 
   const [ keywordsData, setKeywordsData ] = useState([])
 
-  useEffect(function () {
+  useEffect(function onTargetChange_fetchData () {
     if (subject) {
       fetchKeywords(
         projectId,
@@ -41,6 +41,7 @@ function SubjectKeywords ({
         subject
       )
     }
+    // TODO: fetch more than one page of keywords?
   }, [ projectId, subject ])
 
   if (!subject) return (

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -36,7 +36,6 @@ function SubjectKeywords ({
     if (subject) {
       fetchKeywords(
         projectId,
-        setKeywordsData,
         1,  // Page
         subject
       )

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -53,7 +53,7 @@ function SubjectKeywords ({
 
       } catch (err) {
         setStatus(ERROR)
-        console.error(err)
+        console.error('<SubjectKeyword>', err)
       }
     }
   }

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -55,9 +55,8 @@ export default function SubjectViewer ({
   const subjectId = subject?.id
   const [ index, setIndex ] = useState(0)
 
-  useEffect(function onSubjectChange () {
+  useEffect(function onTargetChange_resetData () {
     setIndex(0)
-
   }, [subject])
 
   function goPrevIndex () {

--- a/src/helpers/fetchKeywords.js
+++ b/src/helpers/fetchKeywords.js
@@ -45,7 +45,7 @@ export default async function fetchKeywords (
     return keywords
 
   } catch (err) {
-    console.error(err)
+    console.error('fetchKeyword()', err)
     throw(err)
   }
 }

--- a/src/helpers/fetchKeywords.js
+++ b/src/helpers/fetchKeywords.js
@@ -3,7 +3,6 @@ Fetches keywords (Talk tags) from a project, or from a specific Subject in that 
 
 Inputs:
 - (string) projectId
-- (function) setData: callback function after successful data fetch
 - (number) page
 - (optional) (object) subject: Zooniverse Subject resource.
   Specify only if we want tags for that specific Subject.
@@ -18,7 +17,6 @@ import { PAGE_SIZE } from '@src/config.js'
 
 export default async function fetchKeywords (
   projectId,
-  setData = (data) => { console.log('fetchKeywords: ', data) },
   page = 1,
   subject = undefined,
 ) {
@@ -44,7 +42,7 @@ export default async function fetchKeywords (
     if (!response?.ok) throw new Error('Couldn\'t fetch keywords')
 
     const keywords = response.body?.popular || []
-    setData(keywords)
+    return keywords
 
   } catch (err) {
     console.error(err)

--- a/src/helpers/fetchKeywords.js
+++ b/src/helpers/fetchKeywords.js
@@ -47,6 +47,5 @@ export default async function fetchKeywords (
   } catch (err) {
     console.error(err)
     throw(err)
-    // TODO: handle errors
   }
 }

--- a/src/helpers/fetchRandomSubjects.js
+++ b/src/helpers/fetchRandomSubjects.js
@@ -35,7 +35,7 @@ export default async function fetchRandomSubjects (
     return results?.rows?.map(item => (item[indexOfSubjectId] || '').toString()) || []
 
   } catch (err) {
-    console.error(err)
+    console.error('fetchRandomSubjects()', err)
     throw(err)
   }
 }

--- a/src/helpers/fetchRandomSubjects.js
+++ b/src/helpers/fetchRandomSubjects.js
@@ -37,6 +37,5 @@ export default async function fetchRandomSubjects (
   } catch (err) {
     console.error(err)
     throw(err)
-    // TODO: handle errors
   }
 }

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -5,7 +5,6 @@ Inputs:
 - (object) project: project config object (see projects.json)
 - (string) query
   e.g. to search for Talk posts tagged with "#penguins", pass in queryString="penguins"
-- (function) setData: callback function after successful data fetch
 
 Outputs:
 - Array of unique subject IDs (strings)

--- a/src/helpers/fetchSearchResults_fromDatabase.js
+++ b/src/helpers/fetchSearchResults_fromDatabase.js
@@ -41,7 +41,7 @@ export default async function fetchSearchResults_fromDatabase (
     return results?.rows?.map(item => (item[indexOfSubjectId] || '').toString()) || []
 
   } catch (err) {
-    console.error(err)
+    console.error('fetchSearchResults_fromDatabase()', err)
     throw(err)
     // TODO: handle errors
   }

--- a/src/helpers/fetchSearchResults_fromTalk.js
+++ b/src/helpers/fetchSearchResults_fromTalk.js
@@ -37,7 +37,7 @@ export default async function fetchSearchResults_fromTalk (
     return results.map(item => item.taggable_id?.toString() || '') || []
 
   } catch (err) {
-    console.error(err)
+    console.error('fetchSearchResults_fromTalk()', err)
     throw(err)
     // TODO: handle errors
   }

--- a/src/helpers/fetchSubject.js
+++ b/src/helpers/fetchSubject.js
@@ -18,7 +18,7 @@ export default async function fetchSubject (subjectId) {
     const [ data ] = body.subjects
     return data
   } catch (err) {
-    console.error(err)
+    console.error('fetchSubject()', err)
     throw(err)
   }
 }

--- a/src/helpers/fetchSubject.js
+++ b/src/helpers/fetchSubject.js
@@ -3,7 +3,6 @@ Fetches a Zooniverse Subject resource
 
 Inputs:
 - (string) subjectId
-- (function) setData: callback function after successful data fetch
 
 Outputs:
 - (object) Zooniverse Subject resource.
@@ -11,18 +10,15 @@ Outputs:
 
 import { subjects } from '@zooniverse/panoptes-js'
 
-export default async function fetchSubject (
-  subjectId,
-  setData = (data) => { console.log('fetchSubject: ', data) },
-) {
+export default async function fetchSubject (subjectId) {
   if (!subjectId) return
 
   try {
     const { body } = await subjects.get({ id: subjectId })
     const [ data ] = body.subjects
-    setData(data)
+    return data
   } catch (err) {
-    console.error('ERROR: ', err)
-    // TODO: handle errors
+    console.error(err)
+    throw(err)
   }
 }

--- a/src/pages/ProjectPage/ProjectPage.js
+++ b/src/pages/ProjectPage/ProjectPage.js
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { Box, Button, Carousel, Text } from 'grommet'
 import { observer } from 'mobx-react'
 

--- a/src/pages/SearchPage/SearchPage.js
+++ b/src/pages/SearchPage/SearchPage.js
@@ -10,7 +10,8 @@ function SearchPage () {
   const query = getQuery() || ''
   const location = useLocation()
   
-  useEffect(function onUrlChange () {
+  useEffect(function onUrlChange_doNothing () {
+    // Does nothing technically, but ensures changes to 'query' are listened to properly.
     console.log('Query parameters changed, refreshing Search Page.')
   }, [ location ])
 

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -45,7 +45,7 @@ function SubjectPage () {
       setStatus(READY)
     } catch (err) {
       setStatus(ERROR)
-      console.error(err)
+      console.error('SubjectPage', err)
     }
   }
 
@@ -79,8 +79,9 @@ function SubjectPage () {
         level='2'
         margin={{ horizontal: 'small', vertical: 'xsmall' }}
         size='1.1em'
+        color={(status !== ERROR) ? undefined : 'red' }
       >
-        {title}
+        {(status !== ERROR) ? title : strings.general.error}
       </Heading>
       <Grid
         rows={rows}

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -45,7 +45,7 @@ function SubjectPage () {
       setStatus(READY)
     } catch (err) {
       setStatus(ERROR)
-      console.error('SubjectPage', err)
+      console.error('<SubjectPage>', err)
     }
   }
 

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -24,7 +24,8 @@ function SubjectPage () {
   const subjectId = params.subjectId
   const query = getQuery()
 
-  useEffect(function () {
+  useEffect(function onTargetChange_fetchData () {
+    // fetch new Subject
     fetchSubject(subjectId, setSubjectData)
     // TODO: handle invalid subjects
 


### PR DESCRIPTION
## PR Overview

This PR is a major overhaul/refactor that has very minimal functional changes.

In General:
- Anonymous functions used in useEffect()s are now named. Usually in a `onTrigger_doSomething()` format.
- Fetch functions now eschew the 'setData(results)' pattern, and instead just return the results. Consequently, components have been rewritten to use async `doFetchData()` functions
- Components that fetch data (e.g. SearchResult, SubjectImage, SubjectPage, KeywordsList, SubjectKeywords) now keep track of the fetching status (READY/FETCHING/ERROR) and - in most cases - display that status on the UI in some form.

UI changes:
- SubjectPage: now displays error message in h2 header, if something borks.
- SubjectImage and SearchResult: NO changes, actually. Whether the subject is being fetched, or has encountered an error, the placeholder image is still used.
- KeywordsList and SubjectKeywords: shows fetching status with a spinner. Shows error message if something borks.

Note to self 1: I just realised that subject data is sometimes fetched twice... and then I realised this may be a result of React strict mode rendering each component twice. Hmmm.

Note to self 2: maybe don't overuse the spinner for the smaller components? Check with Sean on this.