### PR TITLE
Functionality Tweaks

### DIFF
--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -7,6 +7,7 @@ import strings from '@src/strings.json'
 import { ASYNC_STATES } from '@src/config.js'
 import { useStores } from '@src/store'
 import fetchSearchResults from '@src/helpers/fetchSearchResults.js'
+import removeDuplicates from '@src/helpers/removeDuplicates.js'
 
 import SearchResult from './SearchResult.js'
 
@@ -56,7 +57,7 @@ function SearchResultsList ({
 
   function addToSearchResults (subjectIds = []) {
     const newResults = [ ...searchResults, ...subjectIds ]
-    const noDuplicates = Array.from(new Set(newResults))
+    const noDuplicates = removeDuplicates(newResults)
     setSearchResults(noDuplicates)
     if (subjectIds.length === 0) setMoreToShow(false)
   }

--- a/src/components/SubjectMetadata/SubjectMetadata.js
+++ b/src/components/SubjectMetadata/SubjectMetadata.js
@@ -34,8 +34,6 @@ export default function SubjectMetadata ({
       <Box>
         {metadata.map((m, i) => {
           const alias = project?.metadata_fields_aliases?.[m.key] || m.key  // Use an alias for the field, if there's one
-          console.log('+++ alias', alias)
-
           return (
             <Box
               key={`subject-metadata-${i}`}

--- a/src/components/SubjectMetadata/SubjectMetadata.js
+++ b/src/components/SubjectMetadata/SubjectMetadata.js
@@ -11,6 +11,7 @@ const KeywordLink = styled(Link)`
 
 export default function SubjectMetadata ({
   subject = undefined,
+  project
 }) {
   if (!subject) return (
     <CodeIcon a11yTitle={strings.general.data_placeholder} />
@@ -31,23 +32,28 @@ export default function SubjectMetadata ({
         {strings.components.subject_metadata.institutional_metadata}
       </Text>
       <Box>
-        {metadata.map((m, i) => (
-          <Box
-            key={`subject-metadata-${i}`}
-            direction='row'
-            margin={{ bottom: 'xsmall' }}
-          >
-            <Text
-              weight='bold'
-              margin={{ right: 'small' }}
+        {metadata.map((m, i) => {
+          const alias = project?.metadata_fields_aliases?.[m.key] || m.key  // Use an alias for the field, if there's one
+          console.log('+++ alias', alias)
+
+          return (
+            <Box
+              key={`subject-metadata-${i}`}
+              direction='row'
+              margin={{ bottom: 'xsmall' }}
             >
-              {m.key}
-            </Text>
-            <Text>
-              {m.value}
-            </Text>
-          </Box>
-        ))}
+              <Text
+                weight='bold'
+                margin={{ right: 'small' }}
+              >
+                {alias}
+              </Text>
+              <Text>
+                {m.value}
+              </Text>
+            </Box>
+          )
+        })}
       </Box>
     </Box>
   )

--- a/src/helpers/fetchSearchResults.js
+++ b/src/helpers/fetchSearchResults.js
@@ -39,9 +39,6 @@ export default async function fetchSearchResults (
       fetchSearchResults_fromDatabase(project.id, queryForDatabase, page)
     ])
   
-    // // Flatten into a single array, then remove duplicates
-    // const subjectIds = Array.from(new Set(allSubjectIds.flat()))
-
     return allSubjectIds.flat()
   }
 }

--- a/src/helpers/removeDuplicates.js
+++ b/src/helpers/removeDuplicates.js
@@ -1,0 +1,18 @@
+/*
+Removes duplicates from an array.
+
+Input:
+- (array) array: usually an array of strings, for comparison purposes.
+
+Outut:
+- Original array, minus duplicates
+
+Example:
+- Input: ['apple', 'banana', 'apple']
+- Output: ['apple', 'banana']
+ */
+
+export default function removeDuplicates (array) {
+  if (!array) return
+  return Array.from(new Set(array))
+}

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -56,7 +56,7 @@ function HomePage () {
           justify='center'
           pad='small'
         >
-          {projectsJson.projects.map(proj => (
+          {projectsJson.projects.filter(proj => !proj.hidden).map(proj => (
             <ProjectCard
               project={proj}
               key={`project-${proj.id}`} 

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -120,7 +120,7 @@ function SubjectPage () {
           justify='around'
           pad={{ top: 'small' }}
         >
-          <SubjectMetadata subject={subjectData} />
+          <SubjectMetadata subject={subjectData} project={project} />
           <SubjectKeywords subject={subjectData} />
         </Box>
         <Box

--- a/src/projects.json
+++ b/src/projects.json
@@ -22,6 +22,8 @@
           "values": [ "true", "yes", "y", "1" ]
         }
       ],
+      "keywords_to_always_suggest": [ "example_keyword", "westindies" ],
+      "keywords_to_never_suggest": [ "devtest" ],
       "advanced_search": [],
       "example_query": "devtest",
       "example_subjects": [
@@ -89,6 +91,8 @@
           "values": [ "true", "yes", "y", "1" ]
         }
       ],
+      "keywords_to_always_suggest": [],
+      "keywords_to_never_suggest": [ "racistlanguage" ],
       "advanced_search": [],
       "example_query": "",
       "example_subjects": [

--- a/src/projects.json
+++ b/src/projects.json
@@ -6,6 +6,7 @@
       "id": 21084,
       "avatar": "",
       "description": "Testing project",
+      "hidden": true,
       "metadata_fields": [
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
       ],

--- a/src/projects.json
+++ b/src/projects.json
@@ -49,6 +49,7 @@
       "id": 12268,
       "avatar": "https://panoptes-uploads.zooniverse.org/project_avatar/f076e3db-9689-4188-9e49-4c7e8d6962d9.jpeg",
       "description": "Travel back in time and take a behind-the-scenes look at the stories, lives and interactions of WWI-era staff and soldiers at the Royal Hospital Chelsea, one of London’s most iconic and longstanding institutions.",
+      "hidden": true,
       "metadata_fields": [
         "Date", "Page", "image", "Catalogue"
       ],

--- a/src/projects.json
+++ b/src/projects.json
@@ -86,6 +86,9 @@
       "metadata_fields_to_search_for_keywords": [
         "image1", "image2", "internal_id", "group_id", "part_number", "folder", "#Hazard", "condition", "item", "picture_agency", "photographer", "sensitive_image_note", "probelmatic_language_notes", "#Other Number", "notes"
       ],
+      "metadata_fields_aliases": {
+        "probelmatic_language_notes": "problematic_language_notes"
+      },
       "sensitive_content_conditions": [
         {
           "field": "sensitive_image",

--- a/src/projects.json
+++ b/src/projects.json
@@ -13,6 +13,9 @@
       "metadata_fields_to_search_for_keywords": [
         "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language"
       ],
+      "metadata_fields_aliases": {
+        "picture_agency": "Picture Agency (PA)"
+      },
       "sensitive_content_conditions": [
         {
           "field": "Sensitive_Image",


### PR DESCRIPTION
## PR Overview

This is PR contains multiple small functionality tweaks

Project config update:
- Add `metadata_fields_aliases`, `hidden`, `keywords_to_always_suggest`, and `keywords_to_never_suggest` fields
- Community Catalog (Stable Testing Project) now uses the new fields to demonstrate how they can be used.
- HDWGH now has keywords to never suggest, and a metadata field alias.
- Both testing projects now set to hidden

Components update:
- HomePage now doesn't show projects marked as 'hidden'
- KeywordsList will now always have keywords marked "always suggest", and will never show keywords marked "never suggest"
- SubjectMetadata now displays the alias of any metadata field, if such an alias exists.

Other:
- `removeDuplicates()` helper function added. Does exactly what it says.