### PR TITLE
Redirect Talk hashtag links

### DIFF
--- a/src/components/SubjectDiscussion/SubjectDiscussion.js
+++ b/src/components/SubjectDiscussion/SubjectDiscussion.js
@@ -97,6 +97,7 @@ export default function SubjectDiscussion ({
   )
 
   const viewOnTalkUrl = project.view_on_talk_url?.replace(/{subject_id}/g, subject.id)
+  const projectUrl = `/projects/${project?.slug}`
 
   return (
     <Box
@@ -117,7 +118,7 @@ export default function SubjectDiscussion ({
                   comment={comment}
                   author={authors[comment.user_id]}
                   authorRoles={authorRoles[comment.user_id]}
-                  projectUrl={project?.project_url}
+                  projectUrl={projectUrl}
                 />
               )))}
             </CommentsContainer>

--- a/src/helpers/getQuery.js
+++ b/src/helpers/getQuery.js
@@ -2,9 +2,9 @@
 Gets ?query parameter from URL. Used to specify user search queries.
  */
 
-export default function getQuery () {
+export default function getQuery (url = window?.location?.search) {
   try {
-    const param = new URLSearchParams(window?.location?.search)
+    const param = new URLSearchParams(url)
     return param.get('query').trim() || undefined
   } catch (err) {
     return undefined

--- a/src/helpers/getQuery.js
+++ b/src/helpers/getQuery.js
@@ -2,9 +2,9 @@
 Gets ?query parameter from URL. Used to specify user search queries.
  */
 
-export default function getQuery (url = window?.location?.search) {
+export default function getQuery () {
   try {
-    const param = new URLSearchParams(url)
+    const param = new URLSearchParams(window?.location?.search)
     return param.get('query').trim() || undefined
   } catch (err) {
     return undefined

--- a/src/projects.json
+++ b/src/projects.json
@@ -43,7 +43,6 @@
         }
       ],
       "title_field": "folder",
-      "project_url": "https://www.zooniverse.org/projects/darkeshard/community-catalog",
       "classify_url": "https://frontend.preview.zooniverse.org/projects/darkeshard/community-catalog/classify/workflow/23968/subject/{subject_id}",
       "view_on_talk_url": "https://www.zooniverse.org/projects/darkeshard/community-catalog/talk/subjects/{subject_id}"
     }, {
@@ -71,7 +70,6 @@
         }
       ],
       "title_field": "Catalogue",
-      "project_url": "https://www.zooniverse.org/projects/bogden/scarlets-and-blues",
       "classify_url": "https://www.zooniverse.org/projects/bogden/scarlets-and-blues",
       "view_on_talk_url": "https://www.zooniverse.org/projects/bogden/scarlets-and-blues/talk/subjects/{subject_id}"
     }, {
@@ -118,7 +116,6 @@
         }
       ],
       "title_field": "folder",
-      "project_url": "https://www.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here",
       "classify_url": "https://frontend.preview.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/classify/workflow/23790/subject/{subject_id}",
       "view_on_talk_url": "https://www.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/talk/subjects/{subject_id}"
     }

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, redirect } from 'react-router-dom'
 import App from '@src/App'
 
 import HomePage from '@src/pages/HomePage'
@@ -6,7 +6,9 @@ import ProjectContainer from '@src/components/ProjectContainer'
 import ProjectPage from '@src/pages/ProjectPage'
 import SearchPage from '@src/pages/SearchPage'
 import SubjectPage from '@src/pages/SubjectPage'
-import Tester from '@src/components/Tester'
+
+import getEnv from '@src/helpers/getEnv.js'
+import getQuery from '@src/helpers/getQuery.js'
 
 export const router = createBrowserRouter([
   {
@@ -15,6 +17,9 @@ export const router = createBrowserRouter([
     errorElement: <h1>Unspecified Error</h1>,
     children: [
       {
+        /*
+        Community Catalog home/landing Page
+         */
         path: '',
         element: <HomePage />,
       },
@@ -23,24 +28,54 @@ export const router = createBrowserRouter([
         element: <ProjectContainer />,
         children: [
           {
+            /*
+            Project home page
+             */
             path: '',
             element: <ProjectPage />,
           },
           {
+            /*
+            Search results page
+             */
             path: 'search',
             element: <SearchPage />,
           },
           {
+            /*
+            Subject page (with no ID, this is actually invalid)
+             */
             path: 'subject',
             element: <SubjectPage />,
           },
           {
+            /*
+            Subject page
+             */
             path: 'subject/:subjectId',
             element: <SubjectPage />,
           },
           {
-            path: 'test',
-            element: <Tester />,
+            /*
+            Redirect "Talk keywords" to search:
+            When users type in hashtag #keywords in Talk, Markdownz will render
+            that as a link with a specific format. We need to translate that
+            "Talk keyword link" to a Community Catalog search query.
+             */
+            path: 'talk/search',
+            element: null,
+            loader: async ({ request, params }) => {
+              console.log('+++ request, params: ', request, params)
+
+              const env = getEnv()
+              const query = getQuery(request.url) || ''
+
+              const redirectUrl = `/projects/${params.projectOwner}/${params.projectName}?query=${query}${env ? `&env=${env}` : ''}`
+
+              console.log('+++ redirectUrl ', redirectUrl)
+
+              // return redirect(redirectUrl)
+            },        
           },
         ]
       }

--- a/src/router.js
+++ b/src/router.js
@@ -65,17 +65,11 @@ export const router = createBrowserRouter([
             path: 'talk/search',
             element: null,
             loader: async ({ request, params }) => {
-              console.log('+++ request, params: ', request, params)
-
               const env = getEnv()
-              const query = getQuery(request.url) || ''
-
-              const redirectUrl = `/projects/${params.projectOwner}/${params.projectName}?query=${query}${env ? `&env=${env}` : ''}`
-
-              console.log('+++ redirectUrl ', redirectUrl)
-
-              return null
-              // return redirect(redirectUrl)
+              const query = (getQuery() || '')
+                            .replace(/#/g, '')
+              const redirectUrl = `/projects/${params.projectOwner}/${params.projectName}/search?query=${query}${env ? `&env=${env}` : ''}`
+              return redirect(redirectUrl)
             },        
           },
         ]

--- a/src/router.js
+++ b/src/router.js
@@ -74,6 +74,7 @@ export const router = createBrowserRouter([
 
               console.log('+++ redirectUrl ', redirectUrl)
 
+              return null
               // return redirect(redirectUrl)
             },        
           },


### PR DESCRIPTION
## PR Overview

The addition of the Markdownz in `<SubjectDiscussion>`'s `<Comment>`s introduced a new problem. When a user types in hashtag keywords (for example, `#Jamaica`), the Markdownz component automatically turns that hashtag into a link _back to the Zooniverse Talk pages._ (For example, https://frontend.preview.zooniverse.org/projects/darkeshard/community-catalog/talk/search?query=#jamaica or https://frontend.preview.zooniverse.org/projects/darkeshard/community-catalog/talk/tags/jamaica)

This PR fixes the issue by redirecting those links back to the Community Catalog's search page.

- SubjectDiscussion/Comment: Markdownz's new "baseURL" is now set to the Community Catalog, instead of the Project's Zooniverse Talk page.
- Router: any visits to `(project)/talk/search` (i.e. the links created by Markdownz) are redirected to `(project)/search`, with the `?query` transformed into something compatible to the search page (i.e. stripping off the `#` from the Talk keyword)

⚠️  This is a bit hacky, but I didn't want to change the global `Markdownz` component from FEM.

Other:
- `project_url` removed from Projects config.
- Note: the previous solution was to direct users to the Project's Zooniverse Talk page and hope for the best.