### PR TITLE
Footer: content update pt2

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,11 +1,13 @@
-import { Footer as GrommetFooter, Text } from 'grommet'
+import { Footer as _GrommetFooter, Text } from 'grommet'
 import { Markdownz } from '@zooniverse/react-components'
 import styled from 'styled-components'
 
 import strings from '@src/strings.json'
 
-const StyledMarkdown = styled(Markdownz)`
-  font-size: 0.75em;
+const GrommetFooter = styled(_GrommetFooter)`
+  p {
+    font-size: 0.75em;
+  }
 `
 
 export default function Footer () {
@@ -20,7 +22,7 @@ export default function Footer () {
       pad='small'
       wrap={true}
     >
-      <StyledMarkdown>{strings.components.footer}</StyledMarkdown>
+      <Markdownz>{strings.components.footer}</Markdownz>
     </GrommetFooter>
   )
 }

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -13,7 +13,6 @@ export default function Footer () {
     <GrommetFooter
       align='center'
       alignContent='center'
-      as='header'
       background='black'
       className='footer'
       direction='column'

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -1,10 +1,12 @@
-import { Footer as _GrommetFooter, Text } from 'grommet'
+import { Box, Footer as GrommetFooter } from 'grommet'
 import { Markdownz } from '@zooniverse/react-components'
 import styled from 'styled-components'
 
 import strings from '@src/strings.json'
 
-const GrommetFooter = styled(_GrommetFooter)`
+const TextBox = styled(Box)`
+  max-width: 36.5em;
+  
   p {
     font-size: 0.75em;
   }
@@ -22,7 +24,9 @@ export default function Footer () {
       pad='small'
       wrap={true}
     >
-      <Markdownz>{strings.components.footer}</Markdownz>
+      <TextBox pad={{ horizontal: 'medium' }}>
+        <Markdownz>{strings.components.footer}</Markdownz>
+      </TextBox>
     </GrommetFooter>
   )
 }


### PR DESCRIPTION
## PR Overview

Follows #141

Whoops, I just realised there were some flaws with the footer I updated previously.

- Apparently, the footer was being rendered as 'header' instead of 'footer'. That's a high quality DERP right there.
- 0.75em font size wasn't triggering properly; I shouldn't have tried to style the Markdownz component.
- Layout has been centre-aligned and max-width-ed to match the Landing Page's intro text. Because having no max-width makes the now long footer text cover way too much of the screen.