### PR TITLE
Add Stereovision project

### DIFF
--- a/src/projects.json
+++ b/src/projects.json
@@ -124,6 +124,7 @@
         "id": 23052,
         "avatar": "https://panoptes-uploads.zooniverse.org/project_avatar/576b37cd-4d27-4752-95e4-d870890f8f2c.jpeg",
         "description": "Help make our collections at National Museums Scotland more accessible by classifying 19th century stereographs of the Great Exhibition of 1862, through creating keywords and alternative descriptions. ",
+        "hidden": true,
         "metadata_fields": [
           "file name", "object_number", "object_name", "creator", "creator.role", "production.date", "association.person", "credit line"
         ],

--- a/src/projects.json
+++ b/src/projects.json
@@ -116,7 +116,7 @@
         }
       ],
       "title_field": "folder",
-      "classify_url": "https://frontend.preview.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/classify/workflow/23790/subject/{subject_id}",
+      "classify_url": "https://www.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/classify/workflow/23790/subject/{subject_id}",
       "view_on_talk_url": "https://www.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/talk/subjects/{subject_id}"
       }, {
         "name": "Stereovision",

--- a/src/projects.json
+++ b/src/projects.json
@@ -118,6 +118,41 @@
       "title_field": "folder",
       "classify_url": "https://frontend.preview.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/classify/workflow/23790/subject/{subject_id}",
       "view_on_talk_url": "https://www.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/talk/subjects/{subject_id}"
-    }
+      }, {
+        "name": "Stereovision",
+        "slug": "juliehgibb/stereovision",
+        "id": 23052,
+        "avatar": "https://panoptes-uploads.zooniverse.org/project_avatar/576b37cd-4d27-4752-95e4-d870890f8f2c.jpeg",
+        "description": "Help make our collections at National Museums Scotland more accessible by classifying 19th century stereographs of the Great Exhibition of 1862, through creating keywords and alternative descriptions. ",
+        "metadata_fields": [
+          "file name", "object_number", "object_name", "creator", "creator.role", "production.date", "association.person", "credit line"
+        ],
+        "metadata_fields_to_search_for_keywords": [
+          "file name", "object_number", "object_name", "creator", "creator.role", "production.date", "association.person", "credit line"
+        ],
+        "metadata_fields_aliases": {},
+        "sensitive_content_conditions": [],
+        "keywords_to_always_suggest": [],
+        "keywords_to_never_suggest": [],
+        "advanced_search": [],
+        "example_query": "",
+        "example_subjects": [
+          {
+            "id": "100295709",
+            "title": "T.2023.44.6.15.142_001.jpg"
+          },
+          {
+            "id": "100295710",
+            "title": "T.2023.44.6.15.143_001.jpg"
+          },
+          {
+            "id": "100295703",
+            "title": "T.2023.44.6.15.121_001.jpg"
+          }
+        ],
+        "title_field": "file name",
+        "classify_url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26599/subject/{subject_id}",
+        "view_on_talk_url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/talk/subjects/{subject_id}"
+      }
   ]
 }


### PR DESCRIPTION
## PR Overview

This PR adds the Stereovision project to the Community Catalog.

- As the project is still in development, it's hidden from the home page.
- To access the project on the Community Catalog, use this URL: https://community-catalog.zooniverse.org/projects/juliehgibb/stereovision/
- Alternatively, on localhost: https://local.zooniverse.org:8080/projects/juliehgibb/stereovision/?env=production

See also:
- Stereovision added to the Subject Set Search API: https://github.com/zooniverse/subject-set-search-api/pull/68 and https://github.com/zooniverse/subject-set-search-api/pull/69

Also in this PR:
- 🛠️ FIX: "How Did We Get Here"'s **Classify links** now take users to the full Zooniverse URL, instead of the FEM preview URL.

Context: the Stereovision project is the second project to be supported on the Community Catalog. We'll see what updates need to be made to the catalogue to allow it to support different projects.

### Dev Notes

- As of time of writing, the Stereovision project either hasn't gone public (AFAIK). I'm assuming the metadata might still change.
- ⚠️ Limitations & issues uncovered during initial tests:
  - ❓ the Subject Set Search API seems to be indexing Subjects that have been deleted? Needs to be investigated.
  - ❗ the Community Catalog's Subject page [(example)](https://community-catalog.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/subject/90433314) has a "Classify This Subject" link... but that assumes the project only has one workflow. Stereovision has **two active workflows.**
  - The Stereovision project needs to pick a good "description field". For testing, we're just using "file name", erm.
  - The Stereovision project probably doesn't need a "Show Sensitive Images" toggle... probably?

### Status

Merging and deploying ASAP so Sam & Sean can preview.