### PR TITLE
Support multiple workflows for "Classify This Subject"

### DIFF
--- a/src/components/ProjectContainer/ProjectContainer.js
+++ b/src/components/ProjectContainer/ProjectContainer.js
@@ -1,12 +1,18 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
+import { Box, Spinner } from 'grommet'
 
+import { ASYNC_STATES } from '@src/config.js'
 import strings from '@src/strings.json'
 import { useStores } from '@src/store'
 import projectsJson from '@src/projects.json'
+import fetchProjectData from '@src/helpers/fetchProjectData.js'
+
+const { READY, FETCHING, ERROR } = ASYNC_STATES
 
 export default function ProjectContainer ({}) {
-  const store = useStores()
+  const { setProject, projectData, setProjectData } = useStores()
+  const [ status, setStatus ] = useState(READY)
 
   const params = useParams()
   const projectOwner = params.projectOwner || ''
@@ -14,16 +20,48 @@ export default function ProjectContainer ({}) {
   const projectSlug = `${projectOwner}/${projectName}`.toLowerCase()
   const selectedProject = projectsJson.projects.find(p => p.slug === projectSlug)
 
+  async function doFetchData (projectId) {
+    if (!projectId) return
+    try {
+      setStatus(FETCHING)
+      const projectData = await fetchProjectData(projectId?.toString?.())
+      setProjectData(projectData)
+      setStatus(READY)
+    } catch (err) {
+      setStatus(ERROR)
+      console.error('<ProjectContainer>', err)
+    }
+  }
+
   function onUnload () {
-    store.setProject(undefined)
+    setProject(undefined)
+    setProjectData(undefined)
   }
 
   useEffect(function onTargetChange_setData () {
-    store.setProject(selectedProject)
+    setProject(selectedProject)
+    doFetchData(selectedProject.id)
     return onUnload
   }, [ selectedProject ])
 
   if (!selectedProject) throw new Error(strings?.errors?.could_not_find_project || 'Could not find project')
+
+  if (selectedProject && !projectData) {
+    return (
+      <Box
+        align='center'
+        justify='center'
+        pad='small'
+      >
+        <Spinner
+          message={{
+            start: strings.messages.project_data_fetching,
+            end: strings.messages.project_data_ready
+          }}
+        />
+      </Box>
+    )
+  }
 
   return (
     <Outlet />

--- a/src/components/ProjectContainer/ProjectContainer.js
+++ b/src/components/ProjectContainer/ProjectContainer.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
-import { Box, Spinner } from 'grommet'
+import { Box, Spinner, Text } from 'grommet'
 
 import { ASYNC_STATES } from '@src/config.js'
 import strings from '@src/strings.json'
@@ -53,12 +53,15 @@ export default function ProjectContainer ({}) {
         justify='center'
         pad='small'
       >
-        <Spinner
-          message={{
-            start: strings.messages.project_data_fetching,
-            end: strings.messages.project_data_ready
-          }}
-        />
+        {(status === FETCHING) && (
+          <Spinner
+            message={{
+              start: strings.messages.project_data_fetching,
+              end: strings.messages.project_data_ready
+            }}
+          />
+        )}
+        {(status === ERROR) && (<Text color='red'>{strings.general.error}</Text>)}
       </Box>
     )
   }

--- a/src/components/SearchResultsList/SearchResultsList.js
+++ b/src/components/SearchResultsList/SearchResultsList.js
@@ -27,6 +27,7 @@ function SearchResultsList ({
   const [ status, setStatus ] = useState(READY)
   const [ page, setPage ] = useState(1)
   const [ moreToShow, setMoreToShow ] = useState(true)  // If there's more to show, then we should show "Show More", you dig?
+  const projectHasSensitiveContent = project?.sensitive_content_conditions?.length > 0
 
   useEffect(function onQueryChange_resetData () {
     setSearchResults([])
@@ -85,12 +86,14 @@ function SearchResultsList ({
           : strings.components.search_results_list.search_results_random  /* No query, so show all results */
         }</Text>
         <Box flex='grow' />
-        <CheckBox
-          checked={showingSensitiveContent}
-          onChange={e => setShowingSensitiveContent(!!e?.target?.checked)}
-          label={<Text>{strings.components.search_results_list.show_sensitive_images}</Text>}
-          reverse={(size !== 'small')}
-        />
+        {projectHasSensitiveContent && (
+          <CheckBox
+            checked={showingSensitiveContent}
+            onChange={e => setShowingSensitiveContent(!!e?.target?.checked)}
+            label={<Text>{strings.components.search_results_list.show_sensitive_images}</Text>}
+            reverse={(size !== 'small')}
+          />
+        )}
       </Box>
       <Box
         direction='row'

--- a/src/components/SubjectActionsPanel/SubjectActionsPanel.js
+++ b/src/components/SubjectActionsPanel/SubjectActionsPanel.js
@@ -1,4 +1,4 @@
-import { Anchor, Box, Text } from 'grommet'
+import { Anchor, Button, Box, Text } from 'grommet'
 import {
   Article as ClassifyIcon,
   BladesHorizontal as CollectionIcon,
@@ -16,14 +16,31 @@ const StyledLink = styled(Anchor)`
   text-transform: uppercase;
 `
 
+const StyledButton = styled(Button)`
+  color: #000000;
+  text-decoration: none;
+  text-transform: uppercase;
+`
+
 export default function SubjectActionsPanel ({
-  project, subject
+  project,
+  subject,
+  showWorkflowSelection = () => {}
 }) {
   if (!project || !subject) return (
     <CodeIcon a11yTitle={strings.general.data_placeholder} />
   )
 
-  const classifySubjectUrl = project.classify_url?.replace(/{subject_id}/g, subject.id)
+  // Some projects only have one Workflow, so clicking on the "Classify Subject"
+  // link will immediately open that Subject on that Workflow. Other projects
+  // have more than one workflow, so we need to open the workflow selection
+  // dialog.
+  const useWorkflowSelection = Array.isArray(project.classify_url)
+  const classifySubjectUrl = (useWorkflowSelection)
+    ? '#'
+    : project.classify_url?.replace(/{subject_id}/g, subject.id)
+
+  console.log('+++ useWorkflowSelection', useWorkflowSelection)
 
   return (
     <Box
@@ -40,13 +57,25 @@ export default function SubjectActionsPanel ({
         label={<Text>{strings.components.subject_actions.add_to_collection}</Text>}
         margin='small'
       />
-      <StyledLink
-        gap='xsmall'
-        href={classifySubjectUrl}
-        icon={<ClassifyIcon size='small' />}
-        label={<Text>{strings.components.subject_actions.classify_subject}</Text>}
-        margin='small'
-      />
+      {(useWorkflowSelection) ? (
+        <StyledButton
+          alignSelf="start"
+          gap='xsmall'
+          icon={<ClassifyIcon size='small' />}
+          label={<Text>{strings.components.subject_actions.classify_subject}</Text>}
+          margin='small'
+          onClick={showWorkflowSelection}
+          plain={true}
+        />
+      ) : (
+        <StyledLink
+          gap='xsmall'
+          href={classifySubjectUrl}
+          icon={<ClassifyIcon size='small' />}
+          label={<Text>{strings.components.subject_actions.classify_subject}</Text>}
+          margin='small'
+        />
+      )}
       <StyledLink
         disabled={true}
         gap='xsmall'

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -12,6 +12,7 @@ import strings from '@src/strings.json'
 import checkForSensitiveContent from '@src/helpers/checkForSensitiveContent.js'
 
 const FILMSTRIP_IMAGE_SIZE = 44
+const MIN_IMAGES_TO_SHOW_FILMSTRIP = 2
 const GOLD_COLOUR = '#F0B200'
 
 const MainImage = styled(Image)`
@@ -153,49 +154,42 @@ export default function SubjectViewer ({
           </SensitiveContentCheckboxBox>
         : null
       }
-      <Box
-        direction='row'
-        justify='center'
-      >
-        {(filmstripSrcs.length > 0)
-          ? <Button
-              a11yTitle={strings.components.subject_viewer.prev_item}
-              icon={<LeftIcon />}
-              onClick={goPrevIndex}
-            />
-          : null
-        }
-
-        {filmstripSrcs.map((filmstripSrc, _index) => {
-          const isSelected = _index === index
-
-          return (
-            <Button
-              key={`subject-viewer-filmstrip-${_index}`}
-              margin={{ horizontal: 'xxsmall', vertical: 'small' }}
-            >
-              <ImageWithBorder
-                /* TODO alt={strings.components.subject_viewer.image.replace(/{index}/g, _index).replace(/{subject_id}/g, subjectId)}*/
-                color={(isSelected) ? GOLD_COLOUR : 'transparent'}
-                fit='cover'
-                src={filmstripSrc}
-                height={FILMSTRIP_IMAGE_SIZE}
-                width={FILMSTRIP_IMAGE_SIZE}
-                onClick={() => { setIndex(_index) }}
-              />
-            </Button>
-          )
-        })}
-
-        {(filmstripSrcs.length > 0)
-          ? <Button
-              a11yTitle={strings.components.subject_viewer.next_item}
-              icon={<RightIcon />}
-              onClick={goNextIndex}
-            />
-          : null
-        }
-      </Box>
+      {(filmstripSrcs.length >= MIN_IMAGES_TO_SHOW_FILMSTRIP) && (
+        <Box
+          direction='row'
+          justify='center'
+        >
+          <Button
+            a11yTitle={strings.components.subject_viewer.prev_item}
+            icon={<LeftIcon />}
+            onClick={goPrevIndex}
+          />
+          {filmstripSrcs.map((filmstripSrc, _index) => {
+            const isSelected = _index === index
+            return (
+              <Button
+                key={`subject-viewer-filmstrip-${_index}`}
+                margin={{ horizontal: 'xxsmall', vertical: 'small' }}
+              >
+                <ImageWithBorder
+                  /* TODO alt={strings.components.subject_viewer.image.replace(/{index}/g, _index).replace(/{subject_id}/g, subjectId)}*/
+                  color={(isSelected) ? GOLD_COLOUR : 'transparent'}
+                  fit='cover'
+                  src={filmstripSrc}
+                  height={FILMSTRIP_IMAGE_SIZE}
+                  width={FILMSTRIP_IMAGE_SIZE}
+                  onClick={() => { setIndex(_index) }}
+                />
+              </Button>
+            )
+          })}
+          <Button
+            a11yTitle={strings.components.subject_viewer.next_item}
+            icon={<RightIcon />}
+            onClick={goNextIndex}
+          />
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -1,0 +1,29 @@
+import { Box, Layer, Paragraph as P } from 'grommet'
+
+import strings from '@src/strings.json'
+
+export default function WorkflowSelectionDialog ({
+  project = undefined,
+  subject = undefined,
+  show = false,
+  onClose = () => {}
+}) {
+  if (!show) return null
+
+  return (
+    <Layer
+      animation="fadeIn"
+      className='workflow-selection-dialog'
+      onEsc={onClose}
+      onClickOutside={onClose}
+    >
+      <Box
+        background='light-1'
+        border={true}
+        pad="large"
+      >
+        <P>{strings.components.workflow_selection_dialog.choose_your_workflow}</P>
+      </Box>
+    </Layer>
+  )
+}

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -36,8 +36,8 @@ export default function WorkflowSelectionDialog ({
         pad={{ top: "small", right: "large", bottom: "large", left: "large" }}
       >
         <P>{strings.components.workflow_selection_dialog.choose_your_workflow}</P>
-        {project.classify_url.map((({ label, value }) => {
-          const classifySubjectUrl = value?.replace(/{subject_id}/g, subject.id)
+        {project.classify_url.map((({ label, url }) => {
+          const classifySubjectUrl = url?.replace(/{subject_id}/g, subject.id)
           return (
             <Box>
               <StyledLink

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -1,6 +1,14 @@
-import { Box, Layer, Paragraph as P } from 'grommet'
+import { Anchor, Box, Layer, Paragraph as P, Text } from 'grommet'
+import styled from 'styled-components' 
+import { Article as ClassifyIcon } from 'grommet-icons'
 
 import strings from '@src/strings.json'
+
+const StyledLink = styled(Anchor)`
+  color: #000000;
+  text-decoration: none;
+  text-transform: uppercase;
+`
 
 export default function WorkflowSelectionDialog ({
   project = undefined,
@@ -8,7 +16,12 @@ export default function WorkflowSelectionDialog ({
   show = false,
   onClose = () => {}
 }) {
-  if (!show) return null
+  if (!show || !project || !subject) return null
+
+  if (!Array.isArray(project.classify_url)) {
+    console.error('<WorkflowSelectionDialog>', strings.errors.expected_classify_url_to_be_array)
+    throw new Error(strings.errors.expected_classify_url_to_be_array)
+  }
 
   return (
     <Layer
@@ -20,9 +33,24 @@ export default function WorkflowSelectionDialog ({
       <Box
         background='light-1'
         border={true}
-        pad="large"
+        pad={{ top: "small", right: "large", bottom: "large", left: "large" }}
       >
         <P>{strings.components.workflow_selection_dialog.choose_your_workflow}</P>
+        {project.classify_url.map((({ label, value }) => {
+          const classifySubjectUrl = value?.replace(/{subject_id}/g, subject.id)
+          return (
+            <Box>
+              <StyledLink
+                gap='xsmall'
+                href={classifySubjectUrl}
+                icon={<ClassifyIcon size='small' />}
+                label={<Text>{label}</Text>}
+                margin='small'
+              />
+            </Box>
+          )
+        }))}
+
       </Box>
     </Layer>
   )

--- a/src/components/WorkflowSelectionDialog/index.js
+++ b/src/components/WorkflowSelectionDialog/index.js
@@ -1,0 +1,1 @@
+export { default } from './WorkflowSelectionDialog.js'

--- a/src/helpers/fetchProjectData.js
+++ b/src/helpers/fetchProjectData.js
@@ -1,0 +1,25 @@
+/*
+Fetches a Zooniverse Project resource
+Not to be confused with the project config in src/projects.json
+
+Inputs:
+- (string) projectId
+
+Outputs:
+- (object) Zooniverse Project resource.
+ */
+
+import { projects } from '@zooniverse/panoptes-js'
+
+export default async function fetchProjectData (projectId) {
+  if (!projectId) return
+
+  try {
+    const { body } = await projects.get({ id: projectId })
+    const [ data ] = body.projects
+    return data
+  } catch (err) {
+    console.error('fetchProjectData()', err)
+    throw(err)
+  }
+}

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -9,6 +9,7 @@ import SubjectDiscussion from '@src/components/SubjectDiscussion'
 import SubjectKeywords from '@src/components/SubjectKeywords'
 import SubjectMetadata from '@src/components/SubjectMetadata'
 import SubjectViewer from '@src/components/SubjectViewer'
+import WorkflowSelectionDialog from '@src/components/WorkflowSelectionDialog'
 
 import { ASYNC_STATES } from '@src/config.js'
 import strings from '@src/strings.json'
@@ -21,6 +22,7 @@ const { READY, FETCHING, ERROR } = ASYNC_STATES
 function SubjectPage () {
   const [ subjectData, setSubjectData ] = useState(undefined)
   const [ status, setStatus ] = useState(READY)
+  const [ workflowSelectionVisible, setWorkflowSelectionVisible ] = useState(false)
   const size = useContext(ResponsiveContext)
 
   const { project, showingSensitiveContent, setShowingSensitiveContent } = useStores()
@@ -70,6 +72,14 @@ function SubjectPage () {
         { name: 'subject-actions', start: [0, 2], end: [0, 2] },
         { name: 'subject-discussion', start: [0, 3], end: [0, 3] },
       ]
+  
+  function showWorkflowSelection () {
+    setWorkflowSelectionVisible(true)
+  }
+
+  function hideWorkflowSelection () {
+    setWorkflowSelectionVisible(false)
+  }
 
   return (
     <Box
@@ -130,6 +140,12 @@ function SubjectPage () {
         </Box>
       </Grid>
       <SearchResultsList query={query} />
+      <WorkflowSelectionDialog
+        project={project}
+        subject={subjectData}
+        show={workflowSelectionVisible}
+        onClose={hideWorkflowSelection}
+      />
     </Box>
   )
 }

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -136,7 +136,11 @@ function SubjectPage () {
         <Box
           gridArea='subject-actions'
         >
-          <SubjectActionsPanel project={project} subject={subjectData} />
+          <SubjectActionsPanel
+            project={project}
+            subject={subjectData}
+            showWorkflowSelection={showWorkflowSelection}
+          />
         </Box>
       </Grid>
       <SearchResultsList query={query} />

--- a/src/projects.json
+++ b/src/projects.json
@@ -155,15 +155,15 @@
         "classify_url": [
           {
             "label": "Classification: Hand-coloured and living people",
-            "value": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26554/subject/{subject_id}"
+            "url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26554/subject/{subject_id}"
           },
           {
             "label": "Alt Text and Extended Description",
-            "value": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26599/subject/{subject_id}"
+            "url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26599/subject/{subject_id}"
           },
           {
             "label": "Keyword classification",
-            "value": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26600/subject/{subject_id}"
+            "url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26600/subject/{subject_id}"
           }
         ],
         "view_on_talk_url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/talk/subjects/{subject_id}"

--- a/src/projects.json
+++ b/src/projects.json
@@ -152,7 +152,20 @@
           }
         ],
         "title_field": "file name",
-        "classify_url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26599/subject/{subject_id}",
+        "classify_url": [
+          {
+            "label": "Classification: Hand-coloured and living people",
+            "value": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26554/subject/{subject_id}"
+          },
+          {
+            "label": "Alt Text and Extended Description",
+            "value": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26599/subject/{subject_id}"
+          },
+          {
+            "label": "Keyword classification",
+            "value": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26600/subject/{subject_id}"
+          }
+        ],
         "view_on_talk_url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/talk/subjects/{subject_id}"
       }
   ]

--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -3,6 +3,7 @@ import { types } from 'mobx-state-tree'
 const AppStore = types.model('AppStore', {
   
   project: types.maybe(types.frozen()),  // Selected Zooniverse project config. See projects.json
+  projectData: types.maybe(types.frozen()),  // Fetched Zooniverse project resource from Panoptes.
   user: types.maybe(types.frozen()),  // Logged in user. It's a Panoptes resource.
   showingSensitiveContent: types.optional(types.boolean, false)  // If enabled, show sensitive images.
   
@@ -11,6 +12,10 @@ const AppStore = types.model('AppStore', {
 
     setProject (val) {
       self.project = val
+    },
+
+    setProjectData (val) {
+      self.projectData = val
     },
 
     setUser (val) {

--- a/src/strings.json
+++ b/src/strings.json
@@ -59,6 +59,9 @@
       "placeholder": "Placeholder for Subject image",
       "prev_item": "View previous image",
       "show_sensitive_images": "Show sensitive images"
+    },
+    "workflow_selection_dialog": {
+      "choose_your_workflow": "Choose which workflow to classify this Subject:"
     }
   },
   "errors": {

--- a/src/strings.json
+++ b/src/strings.json
@@ -66,6 +66,7 @@
   },
   "errors": {
     "could_not_find_project": "Could not find project",
+    "expected_classify_url_to_be_array": "Expected project.classify_url to be an array",
     "general_error": "General Error"
   },
   "general": {

--- a/src/strings.json
+++ b/src/strings.json
@@ -71,8 +71,10 @@
     "error": "ERROR: please see dev console for details"
   },
   "messages": {
-    "app_ready": "App ready.",
     "app_initialising": "Initialising app...",
+    "app_ready": "App ready.",
+    "project_data_fetching": "Fetching project data...",
+    "project_data_ready": "project data ready.",
     "no_keywords_found": "No keywords found, sorry"
   },
   "pages": {


### PR DESCRIPTION
## PR Overview

With addition of the "Stereovision" project (#251), the Community Catalog now needs to support projects that have multiple workflows. (The previous project, "How Did We Get Here?", only had one.)

- New behaviour, on Subject Page:
  - (no change) on a single workflow project, when clicking on "Classify this Project",  the user is immediately taken to the FEM Classify page on www.zooniverse.org
  - 🆕 on a multi workflow project, when clicking on "Classify this Project", the Workflow Selection Dialog (modal) pops up
    -  clicking on a workflow in the modal then takes the user to the FEM Classify page on www.zooniverse.org
- New component: Workflow Selection Dialog
  - Lists all workflows available in a project.
  - Can be closed by either clicking outside modal, or pressing Esc.
  - ⚠️ Needs a design revision, currently using a very basic look.
- Updated Project Config (projects.json):
  - The `project.classify_url` parameter now allows for either a single workflow (default, string) or multiple workflows (array, in the format of `[{ label, url }, ...]`)

Other:
- ProjectContainer: now also fetches the Project Data (Project resource) from Panoptes. This data is currently only used at an experimental level and doesn't really affect anything user-facing (asides from adding a new resource fetch + load screen)
- SearchResultsList: "show sensitive content" checkbox only appears if a project has sensitive content (i.e. `project.sensitive_content_conditions` in the project config isn't an empty array)
- SubjectViewer: the filmstrip is now hidden if the Subject has fewer than 2 images.

### Status

Getting this out ASAP so I can work on the design updates next.