### PR TITLE
Jul 2024 Design Update: Subject Page

### DIFF
--- a/src/components/Header/ProjectHeader.js
+++ b/src/components/Header/ProjectHeader.js
@@ -164,7 +164,7 @@ function ProjectTitle ({
             src={projectAvatarUrl}
           />
         ) : (
-          <ProjectIconPlaceholder
+          <ProjectIconNoAvatar
             size={isNarrowView ? 40 : 80}
           />
         )}
@@ -217,7 +217,7 @@ function NarrowProjectControls ({
   )
 }
 
-function ProjectIconPlaceholder({
+function ProjectIconNoAvatar({
   size = 40
 }) {
   return (

--- a/src/components/Header/ProjectHeader.js
+++ b/src/components/Header/ProjectHeader.js
@@ -158,10 +158,16 @@ function ProjectTitle ({
         direction={isNarrowView ? 'column' : 'row'}
         gap='xsmall'
       >
-        <ProjectIcon
-          size={isNarrowView ? '40px' : '80px'}
-          src={projectAvatarUrl}
-        />
+        {projectAvatarUrl ? (
+          <ProjectIcon
+            size={isNarrowView ? '40px' : '80px'}
+            src={projectAvatarUrl}
+          />
+        ) : (
+          <ProjectIconPlaceholder
+            size={isNarrowView ? 40 : 80}
+          />
+        )}
         <Heading
           size={isNarrowView ? '24px' : '32px'}
           level='1'
@@ -209,4 +215,15 @@ function NarrowProjectControls ({
       </StyledAccordionPanel>
     </StyledAccordion>
   )
+}
+
+function ProjectIconPlaceholder({
+  size = 40
+}) {
+  return (
+    <svg viewBox={`0 0 100 100`} width={size} height={size}>
+      <circle stroke='#ffffff' strokeWidth='4' fill='#005D69' cx='50' cy='50' r='48' />
+    </svg>
+  )
+
 }

--- a/src/components/RandomButton/RandomButton.js
+++ b/src/components/RandomButton/RandomButton.js
@@ -63,7 +63,7 @@ export default function RandomButton ({
       color='#005D69'
       className='random-button'
       headerVariant={headerVariant}
-      icon={headerVariant ? <ZooniverseLogo /> : null}
+      icon={headerVariant ? <ZooniverseLogo id='randomButton-zooniverseLogo' /> : null}
       gap={headerVariant ? '6px' : null}
       primary
       busy={isWorking}

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -23,6 +23,22 @@ const MainImage = styled(Image)`
   }
 `
 
+const ImageContainer = styled(Box)`
+  position: relative;
+`
+
+// Subject Details appear "on top" of the Subject image.
+// ImageContainer needs to have position: relative to anchor SubjectDetails's position: absolute.
+const SubjectDetails = styled(Box)`
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  max-width: 100%;
+  background: rgb(128,128,128,0.5);
+  background: linear-gradient(0deg, rgba(128,128,128,1) 0%, rgba(0,0,0,0) 100%);
+`
+
 const TextWithShadow = styled(Text)`
   text-shadow: 0px 0px 2px #808080;
 `
@@ -57,6 +73,11 @@ export default function SubjectViewer ({
   const viewerWidth = DEFAULT_SUBJECT_VIEWER_WIDTH
   const viewerHeight = DEFAULT_SUBJECT_VIEWER_HEIGHT
 
+  const title = (subjectId)
+    ? subjectData?.metadata?.[project?.title_field]  // Use the title field of the Subject, if any
+      || strings.pages.subject_page.title.replace(/{subject_id}/g, subjectId)  //
+    : strings.pages.subject_page.no_subject  // If there's no subject ID, then there's no subject.
+
   useEffect(function onTargetChange_resetData () {
     setIndex(0)
   }, [subject])
@@ -89,7 +110,7 @@ export default function SubjectViewer ({
     <Box
       className='subject-viewer'
     >
-      <Box
+      <ImageContainer
         background='light-1'
         border={true}
         width={`${viewerWidth}px`}
@@ -111,7 +132,18 @@ export default function SubjectViewer ({
             size='large'
           />
         )}
-      </Box>
+        {subject && !hideContent && (
+          <SubjectDetails
+            pad='small'
+          >
+            <TextWithShadow
+              color='white'
+            >
+              {title}
+            </TextWithShadow>
+          </SubjectDetails>
+        )}
+      </ImageContainer>
       {(hideContent)
         ? <SensitiveContentBox
             align='center'
@@ -134,7 +166,7 @@ export default function SubjectViewer ({
           </SensitiveContentBox>
         : null
       }
-      {(hasSensitiveContent)
+      {(hasSensitiveContent && !showSensitive)
         ? <SensitiveContentCheckboxBox
             align='end'
             justify='center'

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -8,6 +8,7 @@ import {
 } from 'grommet-icons'
 import styled from 'styled-components'
 
+import { DEFAULT_SUBJECT_VIEWER_WIDTH, DEFAULT_SUBJECT_VIEWER_HEIGHT } from '@src/config.js'
 import strings from '@src/strings.json'
 import checkForSensitiveContent from '@src/helpers/checkForSensitiveContent.js'
 
@@ -49,12 +50,12 @@ export default function SubjectViewer ({
   setShowSensitive = () => {},
   showSensitive,
   subject = undefined,
-  width = 200,
-  height = 200,
 }) {
   const subjectData = subject  // Look a lot of the other code I'm copy-pasting uses 'subjectData' so it's easier to rename the variable
   const subjectId = subject?.id
   const [ index, setIndex ] = useState(0)
+  const viewerWidth = DEFAULT_SUBJECT_VIEWER_WIDTH
+  const viewerHeight = DEFAULT_SUBJECT_VIEWER_HEIGHT
 
   useEffect(function onTargetChange_resetData () {
     setIndex(0)
@@ -91,8 +92,8 @@ export default function SubjectViewer ({
       <Box
         background='light-1'
         border={true}
-        width={`${width}px`}
-        height={`${height}px`}
+        width={`${viewerWidth}px`}
+        height={`${viewerHeight}px`}
         align={imgSrc ? undefined : 'center'} 
         justify={imgSrc ? undefined : 'center'}
         overflow='hidden' 
@@ -116,8 +117,8 @@ export default function SubjectViewer ({
             align='center'
             pad='small'
             justify='center'
-            width={`${width}px`}
-            height={`${height}px`}
+            width={`${viewerWidth}px`}
+            height={`${viewerHeight}px`}
           >
             <SensitiveContentIcon
               color='white'

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -7,6 +7,7 @@ import {
   Image as ImageIcon
 } from 'grommet-icons'
 import styled from 'styled-components'
+import { ZooniverseLogo } from '@zooniverse/react-components'
 
 import { DEFAULT_SUBJECT_VIEWER_WIDTH, DEFAULT_SUBJECT_VIEWER_HEIGHT } from '@src/config.js'
 import strings from '@src/strings.json'
@@ -39,7 +40,15 @@ const SubjectDetails = styled(Box)`
   background: linear-gradient(0deg, rgba(128,128,128,1) 0%, rgba(0,0,0,0) 100%);
 `
 
+const StyledButton = styled(Button)`
+  border-radius: 0.5em;
+  flex: 0 0 auto;
+  padding: 7px;
+  width: 200px;
+`
+
 const TextWithShadow = styled(Text)`
+  flex: 1 1 auto;
   text-shadow: 0px 0px 2px #808080;
 `
 
@@ -62,6 +71,7 @@ const SensitiveContentCheckboxBox = styled(Box)`
 `
 
 export default function SubjectViewer ({
+  openWorkflowSelection = () => {},
   project = undefined,
   setShowSensitive = () => {},
   showSensitive,
@@ -106,6 +116,15 @@ export default function SubjectViewer ({
   const hasSensitiveContent = checkForSensitiveContent(subjectData, project)
   const hideContent = (!showSensitive && hasSensitiveContent)
 
+  // Some projects only have one Workflow, so clicking on the "Classify Subject"
+  // link will immediately open that Subject on that Workflow. Other projects
+  // have more than one workflow, so we need to open the workflow selection
+  // dialog.
+  const useWorkflowSelection = Array.isArray(project?.classify_url)
+  const classifySubjectUrl = (useWorkflowSelection)
+    ? undefined
+    : project?.classify_url?.replace(/{subject_id}/g, subject?.id)
+
   return (
     <Box
       className='subject-viewer'
@@ -134,13 +153,29 @@ export default function SubjectViewer ({
         )}
         {subject && !hideContent && (
           <SubjectDetails
+            align='center'
+            cssGap={true}
+            direction='row'
+            gap='small'
             pad='small'
           >
             <TextWithShadow
               color='white'
+              size='18px'
+              weight='bold'
             >
               {title}
             </TextWithShadow>
+            <StyledButton
+              color='#005D69'
+              className='classify-button'
+              icon={<ZooniverseLogo id='classifyButton-zooniverseLogo' />}
+              gap={'6px'}
+              href={classifySubjectUrl}
+              primary
+              label={strings.components.subject_actions.classify_subject}
+              onClick={useWorkflowSelection ? openWorkflowSelection : undefined}
+            />
           </SubjectDetails>
         )}
       </ImageContainer>

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,9 @@ export const NARROW_VIEW_WIDTH = 800  // At this width of below, we'll use a nar
 export const PROJECT_CARD_WIDTH = 222
 export const PROJECT_CARD_HEIGHT = 265
 
+export const DEFAULT_SUBJECT_VIEWER_WIDTH = 1000
+export const DEFAULT_SUBJECT_VIEWER_HEIGHT = 500
+
 // Data fetch stuff
 export const ASYNC_STATES = {
   READY: 'ready',

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -89,8 +89,7 @@ function SubjectPage () {
       <Grid
         rows={rows}
         columns={columns}
-        pad={{ horizontal: 'small', vertical: 'none' }}
-        margin={{ bottom: 'small' }}
+        pad='small'
         gap='small'
         areas={areas}
       >
@@ -115,7 +114,6 @@ function SubjectPage () {
           />
         </Box>
         <Box
-          border={{ color: 'light-3', size: 'small', style: 'solid', side: 'top' }}
           gridArea='subject-metadata-and-keywords'
           direction='row'
           gap='small'

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -57,20 +57,18 @@ function SubjectPage () {
     : strings.pages.subject_page.no_subject  // If there's no subject ID, then there's no subject.
 
   const isNarrowView = size === 'small'
-  const rows = (!isNarrowView) ? ['auto', 'auto'] : ['auto', 'auto', 'auto', 'auto']
+  const rows = (!isNarrowView) ? ['auto', 'auto'] : ['auto', 'auto', 'auto']
   const columns = (!isNarrowView) ? ['auto', '1/3'] : ['auto']
   const areas = (!isNarrowView)
     ? [
         { name: 'subject-viewer', start: [0, 0], end: [0, 0] },
-        { name: 'subject-discussion', start: [1, 0], end: [1, 0] },
+        { name: 'subject-discussion', start: [1, 0], end: [1, 1] },
         { name: 'subject-metadata-and-keywords', start: [0, 1], end: [0, 1] },
-        { name: 'subject-actions', start: [1, 1], end: [1, 1] },
       ]
     : [
         { name: 'subject-viewer', start: [0, 0], end: [0, 0] },
         { name: 'subject-metadata-and-keywords', start: [0, 1], end: [0, 1] },
-        { name: 'subject-actions', start: [0, 2], end: [0, 2] },
-        { name: 'subject-discussion', start: [0, 3], end: [0, 3] },
+        { name: 'subject-discussion', start: [0, 2], end: [0, 2] },
       ]
   
   function showWorkflowSelection () {
@@ -131,6 +129,7 @@ function SubjectPage () {
           <SubjectMetadata subject={subjectData} project={project} />
           <SubjectKeywords subject={subjectData} />
         </Box>
+        {/*
         <Box
           gridArea='subject-actions'
         >
@@ -140,6 +139,7 @@ function SubjectPage () {
             showWorkflowSelection={showWorkflowSelection}
           />
         </Box>
+        */}
       </Grid>
       <SearchResultsList query={query} />
       <WorkflowSelectionDialog

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -108,8 +108,6 @@ function SubjectPage () {
           <SubjectViewer
             subject={subjectData}
             project={project}
-            width={1000}
-            height={500}
             showSensitive={showingSensitiveContent}
             setShowSensitive={setShowingSensitiveContent}
           />

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -1,10 +1,9 @@
 import { useContext, useEffect, useState } from 'react'
-import { Box, Grid, Heading, ResponsiveContext, Text } from 'grommet'
+import { Box, Grid, ResponsiveContext, Text } from 'grommet'
 import { useParams } from 'react-router-dom'
 import { observer } from 'mobx-react'
 
 import SearchResultsList from '@src/components/SearchResultsList'
-import SubjectActionsPanel from '@src/components/SubjectActionsPanel'
 import SubjectDiscussion from '@src/components/SubjectDiscussion'
 import SubjectKeywords from '@src/components/SubjectKeywords'
 import SubjectMetadata from '@src/components/SubjectMetadata'
@@ -51,11 +50,6 @@ function SubjectPage () {
     }
   }
 
-  const title = (subjectId)
-    ? subjectData?.metadata?.[project?.title_field]  // Use the title field of the Subject, if any
-      || strings.pages.subject_page.title.replace(/{subject_id}/g, subjectId)  //
-    : strings.pages.subject_page.no_subject  // If there's no subject ID, then there's no subject.
-
   const isNarrowView = size === 'small'
   const rows = (!isNarrowView) ? ['auto', 'auto'] : ['auto', 'auto', 'auto']
   const columns = (!isNarrowView) ? ['auto', '1/3'] : ['auto']
@@ -71,11 +65,11 @@ function SubjectPage () {
         { name: 'subject-discussion', start: [0, 2], end: [0, 2] },
       ]
   
-  function showWorkflowSelection () {
+  function openWorkflowSelection () {
     setWorkflowSelectionVisible(true)
   }
 
-  function hideWorkflowSelection () {
+  function closeWorkflowSelection () {
     setWorkflowSelectionVisible(false)
   }
 
@@ -105,10 +99,11 @@ function SubjectPage () {
           align='center'
         >
           <SubjectViewer
-            subject={subjectData}
+            openWorkflowSelection={openWorkflowSelection}
             project={project}
             showSensitive={showingSensitiveContent}
             setShowSensitive={setShowingSensitiveContent}
+            subject={subjectData}
           />
         </Box>
         <Box
@@ -147,7 +142,7 @@ function SubjectPage () {
         project={project}
         subject={subjectData}
         show={workflowSelectionVisible}
-        onClose={hideWorkflowSelection}
+        onClose={closeWorkflowSelection}
       />
     </Box>
   )

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
-import { Box, Grid, Heading, ResponsiveContext } from 'grommet'
+import { Box, Grid, Heading, ResponsiveContext, Text } from 'grommet'
 import { useParams } from 'react-router-dom'
 import { observer } from 'mobx-react'
 
@@ -83,14 +83,15 @@ function SubjectPage () {
     <Box
       className='subject-page'
     >
-      <Heading
-        level='2'
-        margin={{ horizontal: 'small', vertical: 'xsmall' }}
-        size='1.1em'
-        color={(status !== ERROR) ? undefined : 'red' }
-      >
-        {(status !== ERROR) ? title : strings.general.error}
-      </Heading>
+      {(status === ERROR) && (
+        <Text
+          margin={{ horizontal: 'small', vertical: 'xsmall' }}
+          size='1.1em'
+          color='red'
+        >
+          {strings.general.error}
+        </Text>
+      )}
       <Grid
         rows={rows}
         columns={columns}


### PR DESCRIPTION
## PR Overview

Follows #253

Figma Design: https://www.figma.com/design/tidtkbpbLYV3p8a2kDy0db/Community-Catalog?node-id=0-1&t=86hSbdjluVHgl5Ul-0

<details>
<summary>(preview)</summary>
<img width="536" alt="image" src="https://github.com/user-attachments/assets/8062fd60-87a5-428d-b39a-6924eb0f0ccf">
</details>

This PR updates the UI of the Community Catalog to better match Sean's design updates from 8 Jul 2024 [(Slack)](https://zooniverse.slack.com/archives/C01MD17KBNW/p1720458107961289). In this PR, I'm updating the SubjectPage design.

- SubjectPage:
  - Layout changed.
  - Subject Title (h2) removed. (An error message will still appear at its place if e.g. you try to view a Subject that doesn't exist.)
  - Subject Actions Panel (Favourite, Share, Classify this Subject, etc) removed.
- SubjectViewer:
  - Now has a  "Subject Details" subcomponent, which contains the now-moved Subject Title (not a h2) and Classify This Subject button.
  - Note: for subjects with sensitive content, the "Show Sensitive Content" button behaves differently. Now, if you check the box, the entire warning system disappears so you can't un-check it. (Reason: because the Show Sensitive Content overlay was clashing with the new Subject Details Overlay) 
  - ❗ The Subject Viewer still isn't interactive, so we can't zoom or pan yet.

Other:
- Projects with no avatars now have a placeholder circle thingy

### Testing

Observe the following Subjects and ensure they don't look terrible and that no UI elements are overlapping, etc:

- Simple subject (2 images, should show filmstrip) - https://community-catalog.zooniverse.org/projects/darkeshard/community-catalog/subject/87892458
- Sensitive Content Subject (2 images, should show filmstrip AND start off with a content warning that blurs the image unless a checkbox is clicked) - https://community-catalog.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here/subject/90433294?&query=southafrica
- Simple subject (1 image, no filmstrip) - https://community-catalog.zooniverse.org/projects/juliehgibb/stereovision/subject/100295677?&env=production&query=statues

### Status

Merging, go.