### PR TITLE
Jul 2024 Design Update: Project Page and misc Layout

### DIFF
--- a/src/components/Header/HeaderSearchForm.js
+++ b/src/components/Header/HeaderSearchForm.js
@@ -9,7 +9,12 @@ import getEnv from '@src/helpers/getEnv.js'
 import getQuery from '@src/helpers/getQuery.js'
 
 const StyledForm = styled('form')`
+  flex: 1 0 200px;
   margin: 0;
+
+  @media (min-width: 600px) {
+    max-width: 400px;
+  }
 `
 
 const HeaderSearchInput = styled(TextInput)`

--- a/src/components/Header/ProjectHeader.js
+++ b/src/components/Header/ProjectHeader.js
@@ -48,8 +48,13 @@ const headerLinkProps = {
 }
 
 const ProjectLink = styled(Link)`
+  flex: 1 1 30%;
   text-decoration: none;
   width: 100%;
+`
+
+const ProjectBoxWide = styled(Box)`
+  flex: 1 1 45%;
 `
 
 const StyledAccordion = styled(Accordion)`
@@ -120,11 +125,13 @@ export default function ProjectHeader ({
             label={strings.components.header.project_button}
             href={projectURL}
           />
+          {/*
           <HeaderLink
             {...headerLinkProps}
             label={strings.components.header.talk_button}
             href={talkURL}
           />
+          */}
           <RandomButton
             project={project}
             headerVariant={true}
@@ -186,14 +193,15 @@ function WideProjectControls ({
   children,
 }) {
   return (
-    <Box
+    <ProjectBoxWide
       align='center'
+      cssGap={true}
       direction='row'
-      flex='grow'
       gap='small'
+      justify='end'
     >
       {children}
-    </Box>
+    </ProjectBoxWide>
   )
 }
 

--- a/src/components/SubjectDiscussion/SubjectDiscussion.js
+++ b/src/components/SubjectDiscussion/SubjectDiscussion.js
@@ -18,7 +18,7 @@ const CleanLink = styled(Anchor)`
 `
 
 const CommentsContainer = styled(Box)`
-  max-height: 480px;
+  max-height: 80vh;
 `
 
 const CommentsShadow = styled('div')`

--- a/src/components/SubjectKeywords/SubjectKeywords.js
+++ b/src/components/SubjectKeywords/SubjectKeywords.js
@@ -10,6 +10,11 @@ import { useStores } from '@src/store'
 import fetchKeywords from '@src/helpers/fetchKeywords'
 import Link from '@src/components/Link'
 
+const Container = styled(Box)`
+  border: 1px solid red;
+  flex: 1 0 33%;
+`
+
 const KeywordLink = styled(Link)`
   text-decoration: none;
 `
@@ -63,7 +68,7 @@ function SubjectKeywords ({
   )
 
   return (
-    <Box
+    <Container
       align='end'
       className='subject-keywords'
     >
@@ -98,7 +103,7 @@ function SubjectKeywords ({
         {(status === FETCHING) && (<Spinner />)}
         {(status === ERROR) && (<Text color='red'>{strings.general.error}</Text>)}
       </Box>
-    </Box>
+    </Container>
   )
 }
 

--- a/src/components/SubjectMetadata/SubjectMetadata.js
+++ b/src/components/SubjectMetadata/SubjectMetadata.js
@@ -3,10 +3,10 @@ import { Code as CodeIcon } from 'grommet-icons'
 import styled from 'styled-components'
 
 import strings from '@src/strings.json'
-import Link from '@src/components/Link'
 
-const KeywordLink = styled(Link)`
-  text-decoration: none;
+const Container = styled(Box)`
+  border: 1px solid red;
+  flex: 2 0 66%;
 `
 
 export default function SubjectMetadata ({
@@ -24,7 +24,7 @@ export default function SubjectMetadata ({
     : []
 
   return (
-    <Box
+    <Container
       align='start'
       className='subject-metadata'
     >
@@ -53,7 +53,7 @@ export default function SubjectMetadata ({
           )
         })}
       </Box>
-    </Box>
+    </Container>
   )
 
   /* Table version

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ export const DEFAULT_AVATAR_URL = 'https://static.zooniverse.org/www.zooniverse.
 
 // Layout stuff
 export const SUBJECT_IMAGE_SIZE = 186
-export const LAYOUT_MAIN_MAX_WIDTH = 1280  // App's <main> element will not exceed this width.
+export const LAYOUT_MAIN_MAX_WIDTH = 1440  // App's <main> element will not exceed this width.
 export const NARROW_VIEW_WIDTH = 800  // At this width of below, we'll use a narrow (responsive mobile) view.
 export const PROJECT_CARD_WIDTH = 222
 export const PROJECT_CARD_HEIGHT = 265

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
     <meta name="zooniverse:deployed_commit" content="<%= process.env.HEAD_COMMIT %>">
     <meta name="zooniverse:build_env" content="<%= process.env.NODE_ENV %>">
     <meta name="zooniverse:build_date" content="<%= new Date() %>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       * {
         box-sizing: border-box;

--- a/src/pages/ProjectPage/ProjectPage.js
+++ b/src/pages/ProjectPage/ProjectPage.js
@@ -28,29 +28,27 @@ function ProjectPage () {
         background='dark-1'
         pad='small'
       >
-        <Box
-          alignSelf='center'
-          gap='small'
-          width={`${imgWidth}px`}
+        <Carousel
+          controls='arrows'
+          wrap={true}
         >
-          <Carousel
-            wrap={true}
-          >
-            {exampleSubjects.map(sbj => (
-              <Box key={`example-subject-${sbj.id}`}>
-                <Text>{sbj.title}</Text>
-                <Link to={`/projects/${projectSlug}/subject/${sbj.id}`} key={`landing-subject-${sbj.id}`}>
-                  <SubjectImage
-                    background='dark-1'
-                    subjectId={sbj.id}
-                    width={imgWidth}
-                    height={imgHeight}
-                  />
-                </Link>
-              </Box>
-            ))}
-          </Carousel>
-        </Box>
+          {exampleSubjects.map(sbj => (
+            <Box
+              key={`example-subject-${sbj.id}`}
+              align='center'
+            >
+              <Link to={`/projects/${projectSlug}/subject/${sbj.id}`} key={`landing-subject-${sbj.id}`}>
+                <SubjectImage
+                  background='dark-1'
+                  subjectId={sbj.id}
+                  width={imgWidth}
+                  height={imgHeight}
+                />
+              </Link>
+              {sbj?.title && <Text>{sbj?.title}</Text>}
+            </Box>
+          ))}
+        </Carousel>
       </Box>
       <KeywordsList />
       <SearchResultsList query={query} />

--- a/src/pages/ProjectPage/ProjectPage.js
+++ b/src/pages/ProjectPage/ProjectPage.js
@@ -50,10 +50,6 @@ function ProjectPage () {
               </Box>
             ))}
           </Carousel>
-          <RandomButton
-            project={project}
-            alignSelf='end'
-          />
         </Box>
       </Box>
       <KeywordsList />

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -52,7 +52,7 @@ function SubjectPage () {
 
   const isNarrowView = size === 'small'
   const rows = (!isNarrowView) ? ['auto', 'auto'] : ['auto', 'auto', 'auto']
-  const columns = (!isNarrowView) ? ['auto', '1/3'] : ['auto']
+  const columns = (!isNarrowView) ? ['auto', '400px'] : ['auto']
   const areas = (!isNarrowView)
     ? [
         { name: 'subject-viewer', start: [0, 0], end: [0, 0] },


### PR DESCRIPTION
## PR Overview

Follows #254 

Figma Design: https://www.figma.com/design/tidtkbpbLYV3p8a2kDy0db/Community-Catalog?node-id=0-1&t=86hSbdjluVHgl5Ul-0

<details>
<summary>(preview)</summary>
<img width="607" alt="image" src="https://github.com/user-attachments/assets/d52ab862-9e72-45c2-9ae4-8001a180ede5">
</details>

This PR updates the UI of the Community Catalog to better match Sean's design updates from 8 Jul 2024 [(Slack)](https://zooniverse.slack.com/archives/C01MD17KBNW/p1720458107961289). In this PR, I'm updating the ProjectPage design, alongside with misc layout-related tweaks based on a design discussion on [Slack.](https://zooniverse.slack.com/archives/C01MD17KBNW/p1723131041252059)

- ProjectPage:
  - Remove Random Button under carousel
  - Carousel tweaks
- Layout, General:
  - Main layout's max width increased to 1440px
  - Layout on mobile devices corrected (I forgot the viewport meta)
- Layout, ProjectHeader:
  - Remove Talk link
  - Wider search input
  - Fix responsive layout at widths between 800 and 1000
- Layout, SubjectPage:
  - QuickTalk aka SubjectDiscussion max height changed to 80vh, width fixed to 400px
  - Metadata and Subject Keywords width set to 66% and 33%

### Status

Merging, go.