### PR TITLE
Add getSubjectTitle() to handle Subjects with inconsistent Captalisations in their fIelD NaMes

### DIFF
--- a/src/components/SearchResultsList/SearchResult.js
+++ b/src/components/SearchResultsList/SearchResult.js
@@ -8,6 +8,7 @@ import strings from '@src/strings.json'
 import Link from '@src/components/Link'
 import SubjectImage from '@src/components/SubjectImage'
 import fetchSubject from '@src/helpers/fetchSubject.js'
+import getSubjectTitle from '@src/helpers/getSubjectTitle.js'
 import checkForSensitiveContent from '@src/helpers/checkForSensitiveContent.js'
 
 const { READY, FETCHING, ERROR } = ASYNC_STATES
@@ -33,7 +34,7 @@ export default function SearchResult ({
 }) {
   const [ subjectData, setSubjectData ] = useState(null)
   const [ status, setStatus ] = useState(READY)
-  const title = subjectData?.metadata?.[titleField] || ''
+  const title = getSubjectTitle(subjectData, titleField)
 
   useEffect(function onTargetChange_resetThenFetchData () {
     setStatus(READY)

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -12,6 +12,7 @@ import { ZooniverseLogo } from '@zooniverse/react-components'
 import { DEFAULT_SUBJECT_VIEWER_WIDTH, DEFAULT_SUBJECT_VIEWER_HEIGHT } from '@src/config.js'
 import strings from '@src/strings.json'
 import checkForSensitiveContent from '@src/helpers/checkForSensitiveContent.js'
+import getSubjectTitle from '@src/helpers/getSubjectTitle.js'
 
 const FILMSTRIP_IMAGE_SIZE = 44
 const MIN_IMAGES_TO_SHOW_FILMSTRIP = 2
@@ -83,10 +84,13 @@ export default function SubjectViewer ({
   const viewerWidth = DEFAULT_SUBJECT_VIEWER_WIDTH
   const viewerHeight = DEFAULT_SUBJECT_VIEWER_HEIGHT
 
-  const title = (subjectId)
-    ? subjectData?.metadata?.[project?.title_field]  // Use the title field of the Subject, if any
-      || strings.pages.subject_page.title.replace(/{subject_id}/g, subjectId)  //
-    : strings.pages.subject_page.no_subject  // If there's no subject ID, then there's no subject.
+  let title = ''
+  if (subjectId) {
+    title = getSubjectTitle(subject, project?.title_field)
+            || strings.pages.subject_page.title.replace(/{subject_id}/g, subjectId)
+  } else {
+    title = strings.pages.subject_page.no_subject  // If there's no subject ID, then there's no subject.
+  }
 
   useEffect(function onTargetChange_resetData () {
     setIndex(0)

--- a/src/helpers/getSubjectTitle.js
+++ b/src/helpers/getSubjectTitle.js
@@ -1,0 +1,30 @@
+/*
+Gets the title or description of a Subject. This assumes that the Subject has a
+title or short description of itself in its metadata.
+
+Inputs:
+- (object) subject
+- (string) title field (the name of metadata field which contains a title or short description)
+- (boolean, optional) ignore case (default: true)
+  - this is particularly useful if the Subjects in a project don't use a consistent 
+
+Outputs:
+- (string) title of the Subject
+ */
+
+export default function getSubjectTitle(subject, titleField, ignoreCase = true) {
+  if (!subject || !subject.metadata || !titleField) return ''
+
+  if (ignoreCase) {
+    let title = ''
+    Object.entries(subject.metadata).forEach(([key, val]) => {
+      if (key.toLowerCase?.() === titleField?.toLowerCase?.()) {
+        title = val
+      }
+    })
+    return title
+
+  } else {
+    return subject.metadata[titleField] || ''
+  }
+}

--- a/src/projects.json
+++ b/src/projects.json
@@ -142,18 +142,18 @@
         "example_subjects": [
           {
             "id": "100295709",
-            "title": "T.2023.44.6.15.142_001.jpg"
+            "title": "T.2023.44.6.15.142_001"
           },
           {
             "id": "100295710",
-            "title": "T.2023.44.6.15.143_001.jpg"
+            "title": "T.2023.44.6.15.143_001"
           },
           {
             "id": "100295703",
-            "title": "T.2023.44.6.15.121_001.jpg"
+            "title": "T.2023.44.6.15.121_001"
           }
         ],
-        "title_field": "file name",
+        "title_field": "object_number",
         "classify_url": [
           {
             "label": "Classification: Hand-coloured and living people",


### PR DESCRIPTION
## PR Overview

Follow #257 and https://github.com/zooniverse/subject-set-search-api/pull/73

In the Community Catalog, every Subject has a "title" that's taken from its metadata. This makes a few assumptions:
- the metadata has a field that can more or less describe the subject.
- this field has a consistent _field name_ across every subject

Alas, some projects have Subjects that are inconsistent with the CAPITALisations of their FiEld nAMes, so our previous method of doing something like `title = subject.metadata[project.title_field]` doesn't always work.

This PR solves the issue by adding the getSubjectTitle() helper, which compensates by ignoring the upper/lower case of field names.

Also, the Stereovision proejct's title field is now `object_number` (or `Object_Number` in some cases) instead of `file_name`. It's basically the same, minus the file extension.