### PR TITLE
"Classify this Subject" feature: use live active Workflow data

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -28,7 +28,8 @@ This section describes how a "project config" item in projects.json is structure
 - `name`: display name for the project.
 - `slug`: project slug.
 - `id`: Zooniverse project ID.
-- `avatar`: project avatar (image), displayed on the LandingPage. (URL to an image file)
+- `avatar`: project avatar (image), displayed on the LandingPage and the Header. (URL to an image file)
+- `background`: project background (image), displayed on the ProjectPage. (URL to an image file)
 - `description`: exactly what it says.
 - `hidden`: whether this project should be visible on the LandingPage. (boolean, default false)
 - `metadata_fields`: the fields/columns from the Subject's metadata that we want to show. aka the "institutional metadata" we see on the SubjectPage. (array of strings)
@@ -51,8 +52,10 @@ This section describes how a "project config" item in projects.json is structure
 - `example_query`: query to be used for the SearchResultsList on the ProjectPage. Helps to highlight the initial Subjects a volunteer sees. (string)
 - `example_subjects`: defines the Subjects to be highlighted/displayed on the ProjectPage's carousel. (array of objects)
 - `title_field`: defines which metadata field best _describes_ the Subject. For example, if projectConfig.title_field="short_info", and subject1234.metadata.short_info="A picture of a cat", then Subject 1234 will have the title "A picture of a cat". (string)
-- `classify_url`: URL to classify a specific Subject, on the FEM Classifier (string template, with `{subject_id}` placeholder)
-- `classify_url`: URL to view a specific Subject on Talk (string template, with `{subject_id}` placeholder)
+- `classify_url`: URL to classify a specific Subject, on the FEM Classifier
+  - For most projects with only one workflow, use a string. (string template, with `{subject_id}` placeholder)
+  - For projects with multiple workflows, use an array. (array of `{ label, url }`, with label being any string, and url following the string template format above )
+- `view_on_talk_url`: URL to view a specific Subject on Talk (string template, with `{subject_id}` placeholder)
 </details>
 
 ## /App

--- a/src/README.md
+++ b/src/README.md
@@ -53,8 +53,8 @@ This section describes how a "project config" item in projects.json is structure
 - `example_subjects`: defines the Subjects to be highlighted/displayed on the ProjectPage's carousel. (array of objects)
 - `title_field`: defines which metadata field best _describes_ the Subject. For example, if projectConfig.title_field="short_info", and subject1234.metadata.short_info="A picture of a cat", then Subject 1234 will have the title "A picture of a cat". (string)
 - `classify_url`: URL to classify a specific Subject, on the FEM Classifier
-  - For most projects with only one workflow, use a string. (string template, with `{subject_id}` placeholder)
-  - For projects with multiple workflows, use an array. (array of `{ label, url }`, with label being any string, and url following the string template format above )
+  - For projects with only one workflow, use a string that contains the placeholder `{subject_id}`.
+  - For projects with multiple workflows, or projects that keep changing which workflows are active, use a string that contains the placeholder `{subject_id}` AND `{workflow_id}`.
 - `view_on_talk_url`: URL to view a specific Subject on Talk (string template, with `{subject_id}` placeholder)
 </details>
 

--- a/src/components/SubjectViewer/SubjectViewer.js
+++ b/src/components/SubjectViewer/SubjectViewer.js
@@ -124,7 +124,7 @@ export default function SubjectViewer ({
   // link will immediately open that Subject on that Workflow. Other projects
   // have more than one workflow, so we need to open the workflow selection
   // dialog.
-  const useWorkflowSelection = Array.isArray(project?.classify_url)
+  const useWorkflowSelection = project?.classify_url?.includes('{workflow_id}')
   const classifySubjectUrl = (useWorkflowSelection)
     ? undefined
     : project?.classify_url?.replace(/{subject_id}/g, subject?.id)

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -1,11 +1,12 @@
 import { Anchor, Box, Layer, Paragraph as P, Text } from 'grommet'
-import styled from 'styled-components' 
+import styled, { css } from 'styled-components' 
 import { Article as ClassifyIcon } from 'grommet-icons'
 
 import strings from '@src/strings.json'
 
 const StyledLink = styled(Anchor)`
-  color: #000000;
+  color: ${props => props.color};
+  flex: 1 1 auto;
   text-decoration: none;
   text-transform: uppercase;
 `
@@ -25,7 +26,7 @@ export default function WorkflowSelectionDialog ({
   ))
   // Note: only active workflows are saved in the store, so we don't need to
   // filter for workflow.active = true.
-  
+
   return (
     <Layer
       animation="fadeIn"
@@ -47,19 +48,26 @@ export default function WorkflowSelectionDialog ({
         {validWorkflows.map(workflow => {
           const classifySubjectUrl = project.classify_url?.replace(/{workflow_id}/g, workflow.id).replace(/{subject_id}/g, subject.id)
           const label = workflow.display_name || `Workflow ${workflow.id}`
+          let completeness = workflow.completeness
+          const isComplete = completeness >= 1
           return (
-            <Box key={`workflow-${workflow.id}`}>
+            <Box
+              key={`workflow-${workflow.id}`}
+              direction='row'
+              align='center'
+            >
               <StyledLink
+                color={!isComplete ? '#000000' : '#a0a0a0'}
                 gap='xsmall'
                 href={classifySubjectUrl}
                 icon={<ClassifyIcon size='small' />}
                 label={<Text>{label}</Text>}
                 margin='small'
               />
+              {/*<Text>Completeness {Math.floor(completeness * 100).toFixed(1)}%</Text>*/}
             </Box>
           )
         })}
-
       </Box>
     </Layer>
   )

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -22,7 +22,7 @@ export default function WorkflowSelectionDialog ({
 
   const subjectSetsLinkedToSubject = subject?.links?.subject_sets
   const validWorkflows = workflows.filter(wf => (
-    wf.links?.subject_sets.some(sset => subjectSetsLinkedToSubject?.includes(sset))
+    wf.links?.subject_sets?.some(sset => subjectSetsLinkedToSubject?.includes(sset))
   ))
   // Note: only active workflows are saved in the store, so we don't need to
   // filter for workflow.active = true.

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -13,6 +13,7 @@ const StyledLink = styled(Anchor)`
 export default function WorkflowSelectionDialog ({
   project = undefined,
   subject = undefined,
+  workflows = [],
   show = false,
   onClose = () => {}
 }) {
@@ -23,6 +24,11 @@ export default function WorkflowSelectionDialog ({
     throw new Error(strings.errors.expected_classify_url_to_be_array)
   }
 
+  const subjectSetsLinkedToSubject = subject?.links?.subject_sets
+  const validWorkflows = workflows.filter(wf => (
+    wf.links?.subject_sets.some(sset => subjectSetsLinkedToSubject?.includes(sset))
+  ))
+  
   return (
     <Layer
       animation="fadeIn"

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -38,7 +38,12 @@ export default function WorkflowSelectionDialog ({
         border={true}
         pad={{ top: "small", right: "large", bottom: "large", left: "large" }}
       >
-        <P>{strings.components.workflow_selection_dialog.choose_your_workflow}</P>
+        <P>
+          {validWorkflows.length > 0
+            ? strings.components.workflow_selection_dialog.choose_your_workflow
+            : strings.components.workflow_selection_dialog.no_workflows
+          }
+          </P>
         {validWorkflows.map(workflow => {
           const classifySubjectUrl = project.classify_url?.replace(/{workflow_id}/g, workflow.id).replace(/{subject_id}/g, subject.id)
           const label = workflow.display_name || `Workflow ${workflow.id}`

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -19,15 +19,12 @@ export default function WorkflowSelectionDialog ({
 }) {
   if (!show || !project || !subject) return null
 
-  if (!Array.isArray(project.classify_url)) {
-    console.error('<WorkflowSelectionDialog>', strings.errors.expected_classify_url_to_be_array)
-    throw new Error(strings.errors.expected_classify_url_to_be_array)
-  }
-
   const subjectSetsLinkedToSubject = subject?.links?.subject_sets
   const validWorkflows = workflows.filter(wf => (
     wf.links?.subject_sets.some(sset => subjectSetsLinkedToSubject?.includes(sset))
   ))
+  // Note: only active workflows are saved in the store, so we don't need to
+  // filter for workflow.active = true.
   
   return (
     <Layer
@@ -42,10 +39,11 @@ export default function WorkflowSelectionDialog ({
         pad={{ top: "small", right: "large", bottom: "large", left: "large" }}
       >
         <P>{strings.components.workflow_selection_dialog.choose_your_workflow}</P>
-        {project.classify_url.map((({ label, url }) => {
-          const classifySubjectUrl = url?.replace(/{subject_id}/g, subject.id)
+        {validWorkflows.map(workflow => {
+          const classifySubjectUrl = project.classify_url?.replace(/{workflow_id}/g, workflow.id).replace(/{subject_id}/g, subject.id)
+          const label = workflow.display_name || `Workflow ${workflow.id}`
           return (
-            <Box>
+            <Box key={`workflow-${workflow.id}`}>
               <StyledLink
                 gap='xsmall'
                 href={classifySubjectUrl}
@@ -55,7 +53,7 @@ export default function WorkflowSelectionDialog ({
               />
             </Box>
           )
-        }))}
+        })}
 
       </Box>
     </Layer>

--- a/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
+++ b/src/components/WorkflowSelectionDialog/WorkflowSelectionDialog.js
@@ -43,7 +43,7 @@ export default function WorkflowSelectionDialog ({
             ? strings.components.workflow_selection_dialog.choose_your_workflow
             : strings.components.workflow_selection_dialog.no_workflows
           }
-          </P>
+        </P>
         {validWorkflows.map(workflow => {
           const classifySubjectUrl = project.classify_url?.replace(/{workflow_id}/g, workflow.id).replace(/{subject_id}/g, subject.id)
           const label = workflow.display_name || `Workflow ${workflow.id}`

--- a/src/helpers/fetchWorkflows.js
+++ b/src/helpers/fetchWorkflows.js
@@ -1,0 +1,28 @@
+/*
+Fetches multiple Zooniverse Workflow resource
+
+Inputs:
+- (array) list of workflowIds. Each ID is a string.
+
+Outputs:
+- (object) Zooniverse Workflow resource.
+ */
+
+import { panoptes } from '@zooniverse/panoptes-js'
+
+export default async function fetchWorkflows (workflowIds = []) {
+  if (workflowIds.length === 0) return
+
+  try {
+    const query = {
+      fields: 'active,completeness,display_name',
+      id: workflowIds.join(','),
+    }
+    const { body } = await panoptes.get('/workflows', query)
+    return body.workflows
+
+  } catch (err) {
+    console.error('fetchWorkflows()', err)
+    throw(err)
+  }
+}

--- a/src/pages/SubjectPage/SubjectPage.js
+++ b/src/pages/SubjectPage/SubjectPage.js
@@ -24,7 +24,7 @@ function SubjectPage () {
   const [ workflowSelectionVisible, setWorkflowSelectionVisible ] = useState(false)
   const size = useContext(ResponsiveContext)
 
-  const { project, showingSensitiveContent, setShowingSensitiveContent } = useStores()
+  const { project, workflowsData, showingSensitiveContent, setShowingSensitiveContent } = useStores()
   const params = useParams()
   const subjectId = params.subjectId
   const query = getQuery()
@@ -139,6 +139,7 @@ function SubjectPage () {
       <WorkflowSelectionDialog
         project={project}
         subject={subjectData}
+        workflows={workflowsData}
         show={workflowSelectionVisible}
         onClose={closeWorkflowSelection}
       />

--- a/src/projects.json
+++ b/src/projects.json
@@ -154,20 +154,7 @@
           }
         ],
         "title_field": "object_number",
-        "classify_url": [
-          {
-            "label": "Classification: Hand-coloured and living people",
-            "url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26554/subject/{subject_id}"
-          },
-          {
-            "label": "Alt Text and Extended Description",
-            "url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26599/subject/{subject_id}"
-          },
-          {
-            "label": "Keyword classification",
-            "url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/26600/subject/{subject_id}"
-          }
-        ],
+        "classify_url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/classify/workflow/{workflow_id}/subject/{subject_id}",
         "view_on_talk_url": "https://www.zooniverse.org/projects/juliehgibb/stereovision/talk/subjects/{subject_id}"
       }
   ]

--- a/src/store/AppStore.js
+++ b/src/store/AppStore.js
@@ -4,6 +4,7 @@ const AppStore = types.model('AppStore', {
   
   project: types.maybe(types.frozen()),  // Selected Zooniverse project config. See projects.json
   projectData: types.maybe(types.frozen()),  // Fetched Zooniverse project resource from Panoptes.
+  workflowsData: types.array(types.frozen()),  // Fetched Zooniverse workflow resource(s) from Panoptes.
   user: types.maybe(types.frozen()),  // Logged in user. It's a Panoptes resource.
   showingSensitiveContent: types.optional(types.boolean, false)  // If enabled, show sensitive images.
   
@@ -16,6 +17,10 @@ const AppStore = types.model('AppStore', {
 
     setProjectData (val) {
       self.projectData = val
+    },
+
+    setWorkflowsData (val) {
+      self.workflowsData = val
     },
 
     setUser (val) {

--- a/src/strings.json
+++ b/src/strings.json
@@ -61,7 +61,8 @@
       "show_sensitive_images": "Show sensitive images"
     },
     "workflow_selection_dialog": {
-      "choose_your_workflow": "Choose which workflow to classify this Subject:"
+      "choose_your_workflow": "Choose which workflow to classify this Subject:",
+      "no_workflows": "Unfortunately, this Subject isn't associated with any workflows that are currently active."
     }
   },
   "errors": {


### PR DESCRIPTION
## PR Overview

Our recent experience with the Stereovision project has highlighted the following issues:
- Workflows can be activated and/or inactivated without warning, causing a mismatch in hardcoded project configs.
- Subjects can be de-associated from workflows, making them impossible to Classify (i.e. the subject sets they belong to can be de-associated from active workflows, such as the case with beta test Subjects)

This PR attempts to address the issues above by pulling live _active Workflow_ data for a given Project, and ensuring a Subject "belongs" to at least one active 
- ProjectContainer and AppStore:
  - now fetches all **active workflows** belonging to a Project.
  - Note: this data fetch is considered secondary, and won't block the app from running while it's still ongoing in the background. This is because the WF data is only needed for the "Classify this Subject" feature.
- WorkflowSelectionDialog:
  - lists all active workflows that a Subject is associated with
  - The list of valid workflows is done by comparing `active_workflow.links.subject_sets` and `subject.links.subject_sets`; if there's at least one matching subject set, then a volunteer can classify that Subject on that Workflow.

Also:
- documentation updated to reflect current format of project configs in projects.json

Screenshot: WorkflowSelectionDialog after clicking "Classify this Subject" on a Stereovision Subject

<img width="517" alt="image" src="https://github.com/user-attachments/assets/9289dfd8-2daf-4861-9a0d-593b0b7ee38e">

Screenshot: similar to above, but the Subject is a test subject that's not associated with any active workflows

<img width="670" alt="image" src="https://github.com/user-attachments/assets/67e01e7c-2e7d-4b33-9f4a-abd32f610739">

Future ideas: since we know the completeness of each live workflow, we can also grey out workflows that are complete. The screenshot below demonstrates how this might look like, and the feature is already partially implemented in the code. (We're just missing good design, and actually completed workflows to test it.)

<img width="497" alt="Screenshot 2024-08-13 at 22 31 53" src="https://github.com/user-attachments/assets/5691d89a-84de-4c80-b58b-3ab438e5a792">

NOTE: these changes, when deployed, will only affect the Stereovision project. We could easly apply these changes to How Did We Get Here by changing the project config if we wanted, but I'll try my best to not disturb older projects.

### Status

Ready to go, but do NOT merge and deploy until we get the green light. We don't want to deploy major feature changes while the Stereovision team is still getting a feel for the Community Catalog